### PR TITLE
Security alert: update version of jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <!-- Dependency versions -->
     <version.amqp-client>5.5.0</version.amqp-client>
     <version.assertj>3.8.0</version.assertj>
-    <version.jackson>2.9.7</version.jackson>
+    <version.jackson>2.9.8</version.jackson>
     <version.junit>5.0.2</version.junit>
     <version.junit-surefire>1.0.2</version.junit-surefire>
     <version.logback>1.2.3</version.logback>


### PR DESCRIPTION
This PR updates the version of `jackson` to fix CVE-2018-19360, CVE-2018-19362 and CVE-2018-19361.

This was found during a GitHub Security Scan.