### PR TITLE
JUnit updates

### DIFF
--- a/bdd/pom.xml
+++ b/bdd/pom.xml
@@ -29,16 +29,10 @@
       <version>${cucumber.version}</version>
       <scope>test</scope>
     </dependency>
-    <!--<dependency>-->
-    <!--<groupId>junit</groupId>-->
-    <!--<artifactId>junit</artifactId>-->
-    <!--<version>${junit.version}</version>-->
-    <!--<scope>test</scope>-->
-    <!--</dependency>-->
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <version>4.12.2</version>
+      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -37,7 +37,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -37,7 +37,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,7 @@
     <version.amqp-client>5.6.0</version.amqp-client>
     <version.assertj>3.11.1</version.assertj>
     <version.jackson>2.9.8</version.jackson>
-    <version.junit>5.3.2</version.junit>
-    <version.junit-surefire>1.0.2</version.junit-surefire>
+    <version.junit-jupiter>5.4.0</version.junit-jupiter>
     <version.logback>1.2.3</version.logback>
     <version.mockito>2.24.0</version.mockito>
     <version.slf4j>1.7.25</version.slf4j>
@@ -76,7 +75,7 @@
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
     <version.maven-jacoco-plugin>0.8.3</version.maven-jacoco-plugin>
     <version.maven-javadoc-plugin>3.0.1</version.maven-javadoc-plugin>
-    <version.maven-surefire-plugin>2.19.1</version.maven-surefire-plugin>
+    <version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
     <version.maven-source-plugin>3.0.1</version.maven-source-plugin>
     <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
   </properties>
@@ -121,8 +120,8 @@
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${version.junit}</version>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${version.junit-jupiter}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -187,44 +186,12 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${version.maven-surefire-plugin}</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.junit.jupiter</groupId>
-              <artifactId>junit-jupiter-engine</artifactId>
-              <version>${version.junit}</version>
-            </dependency>
-            <dependency>
-              <groupId>org.junit.platform</groupId>
-              <artifactId>junit-platform-surefire-provider</artifactId>
-              <version>${version.junit-surefire}</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${version.maven-jacoco-plugin}</version>
         </plugin>
-        <!--<plugin>-->
-        <!--<groupId>org.jacoco</groupId>-->
-        <!--<artifactId>jacoco-maven-plugin</artifactId>-->
-        <!--<version>${version.maven-jacoco-plugin}</version>-->
-        <!--<executions>-->
-        <!--<execution>-->
-        <!--<goals>-->
-        <!--<goal>prepare-agent</goal>-->
-        <!--</goals>-->
-        <!--</execution>-->
-        <!--<execution>-->
-        <!--<id>report</id>-->
-        <!--<phase>test</phase>-->
-        <!--<goals>-->
-        <!--<goal>report</goal>-->
-        <!--</goals>-->
-        <!--</execution>-->
-        <!--</executions>-->
-        <!--</plugin>-->
-
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>cobertura-maven-plugin</artifactId>


### PR DESCRIPTION
This PR update the  `junit-jupiter` and `junit-vintage-engine` dependencies.

`junit-jupiter` meta package is used instead of `junit-jupiter-api`.