### PR TITLE
Propagate FlowIds

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ class Application {
 }
 ```
 
+## Propagate FlowIds
+
+If incoming and outgoing message classes implement `HasFlowId`, automated propagation of flow ids is available. If the option `flowBuilder.propagateFlowId(true)` is set, Flusswerk copies flow ids from incoming to all outgoing messages.
+
 ## Message Types
 
 ### Using DefaultMessage

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/Flow.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/Flow.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Recipe for the data processing. Every message will be processed by the readerFactory, then the transformerFactory and finally the writerFactory. The transformerFactory can be omitted if <code>R</code> and <code>W</code> are the same.
+ *
  * @param <M> The data type of the message.
  * @param <R> The data type produced by the reader. Input data type of the transformer.
  * @param <W> The data type consumed by the writer. Output data type of the transformer.
@@ -29,16 +30,25 @@ public class Flow<M extends Message, R, W> {
 
   private final Runnable cleanup;
 
-  public Flow(Supplier<Function<M, R>> readerFactory, Supplier<Function<R, W>> transformerFactory, Supplier<Function<W, Collection<Message>>> writerFactory, Supplier<Consumer<W>> consumingWriterFactory, Runnable cleanup) {
+  private final boolean propagateFlowIds;
+
+  public Flow(
+      Supplier<Function<M, R>> readerFactory,
+      Supplier<Function<R, W>> transformerFactory,
+      Supplier<Function<W, Collection<Message>>> writerFactory,
+      Supplier<Consumer<W>> consumingWriterFactory,
+      Runnable cleanup,
+      boolean propagateFlowIds) {
     this.readerFactory = readerFactory;
     this.transformerFactory = transformerFactory;
     this.writerFactory = writerFactory;
     this.consumingWriterFactory = consumingWriterFactory;
     this.cleanup = cleanup;
+    this.propagateFlowIds = propagateFlowIds;
   }
 
   public Collection<Message> process(M message) {
-    Job<M, R, W> job = new Job<>(message);
+    Job<M, R, W> job = new Job<>(message, propagateFlowIds);
 
     Collection<Message> result = null;
 

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
@@ -31,7 +31,7 @@ public class FlowBuilder<M extends Message, R, W> {
   private boolean propagateFlowIds;
 
   public FlowBuilder() {
-    propagateFlowIds = false;
+    this.propagateFlowIds = false;
   }
 
   @SuppressWarnings("unchecked")

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
@@ -163,6 +163,17 @@ public class FlowBuilder<M extends Message, R, W> {
   }
 
   /**
+   * Copy flowIds from incoming messages to all outgoing messages. Requires both to implement
+   * {@link de.digitalcollections.flusswerk.engine.model.HasFlowId}.
+   * @param propagateFlowIds true to propagate flow ids (default: <code>false</code>)
+   * @return This {@link FlowBuilder} instance for further configuration or creation of the {@link Flow}.
+   */
+  public FlowBuilder<M, R, W> propagateFlowIds(boolean propagateFlowIds) {
+    this.propagateFlowIds = propagateFlowIds;
+    return this;
+  }
+
+  /**
    * Sets cleanup runnable, which is executed after the message was processed.
    *
    * @param runnable The runnable to be executed after the message was processed

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
@@ -28,6 +28,12 @@ public class FlowBuilder<M extends Message, R, W> {
 
   private Runnable cleanup;
 
+  private boolean propagateFlowIds;
+
+  public FlowBuilder() {
+    propagateFlowIds = false;
+  }
+
   @SuppressWarnings("unchecked")
   private W cast(R value) {
     return (W) value;
@@ -174,7 +180,7 @@ public class FlowBuilder<M extends Message, R, W> {
    * @return A new {@link Flow} as configured before.
    */
   public Flow<M, R, W> build() {
-    return new Flow<>(readerFactory, transformerFactory, writerFactory, consumingWriterFactory, cleanup);
+    return new Flow<>(readerFactory, transformerFactory, writerFactory, consumingWriterFactory, cleanup, propagateFlowIds);
   }
 
   public static <M extends Message, R, W> FlowBuilder<M, R, W> receiving(Class<M> clazz) {

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/jackson/FlowMessageMixin.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/jackson/FlowMessageMixin.java
@@ -1,0 +1,10 @@
+package de.digitalcollections.flusswerk.engine.jackson;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_EMPTY)
+public interface FlowMessageMixin {
+}

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/FlowMessage.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/FlowMessage.java
@@ -4,14 +4,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A {@link Message} implementation with an additional identifier to trace
- * jobs through multiple workflow steps.
+ * A {@link Message} implementation with an additional identifier to trace jobs through multiple workflow steps.
  */
 public class FlowMessage extends DefaultMessage implements HasFlowId {
 
   private long flowId;
 
-  protected FlowMessage() {}
+  protected FlowMessage() {
+  }
 
   public FlowMessage(String id) {
     super(id);
@@ -34,8 +34,8 @@ public class FlowMessage extends DefaultMessage implements HasFlowId {
 
   @Override
   public String toString() {
-    return "Message{id=" + getId() + ", flowId=" + getFlowId() +
-           ", envelope=" + getEnvelope() + ", data=" + getData() + "}";
+    return "Message{id=" + getId() + ", flowId=" + getFlowId()
+           + ", envelope=" + getEnvelope() + ", data=" + getData() + "}";
   }
 
 }

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/FlowMessage.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/FlowMessage.java
@@ -1,34 +1,41 @@
 package de.digitalcollections.flusswerk.engine.model;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * A {@link Message} implementation with an additional identifier to trace jobs through multiple workflow steps.
  */
 public class FlowMessage extends DefaultMessage implements HasFlowId {
 
-  private long flowId;
+  private String flowId;
 
   protected FlowMessage() {
   }
 
+  /**
+   * Creates an instance without <code>flowId</code>, in case the Flusswerk shall handle <code>flowId</code> propagation.
+   *
+   * @param id The id of the processed object
+   */
   public FlowMessage(String id) {
     super(id);
-    this.flowId = -1;
+    this.flowId = null;
   }
 
-  public FlowMessage(String id, long flowId) {
+  /**
+   * Creates an instance with <code>flowId</code> for manual handling of <code>flowIds</code>.
+   * @param id The id of the processed object
+   * @param flowId The tracing id through the workflow
+   */
+  public FlowMessage(String id, String flowId) {
     super(id);
     this.flowId = flowId;
   }
 
-  public long getFlowId() {
+  public String getFlowId() {
     return flowId;
   }
 
   @Override
-  public void setFlowId(long flowId) {
+  public void setFlowId(String flowId) {
     this.flowId = flowId;
   }
 

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/FlowMessage.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/FlowMessage.java
@@ -1,0 +1,41 @@
+package de.digitalcollections.flusswerk.engine.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A {@link Message} implementation with an additional identifier to trace
+ * jobs through multiple workflow steps.
+ */
+public class FlowMessage extends DefaultMessage implements HasFlowId {
+
+  private long flowId;
+
+  protected FlowMessage() {}
+
+  public FlowMessage(String id) {
+    super(id);
+    this.flowId = -1;
+  }
+
+  public FlowMessage(String id, long flowId) {
+    super(id);
+    this.flowId = flowId;
+  }
+
+  public long getFlowId() {
+    return flowId;
+  }
+
+  @Override
+  public void setFlowId(long flowId) {
+    this.flowId = flowId;
+  }
+
+  @Override
+  public String toString() {
+    return "Message{id=" + getId() + ", flowId=" + getFlowId() +
+           ", envelope=" + getEnvelope() + ", data=" + getData() + "}";
+  }
+
+}

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/HasFlowId.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/HasFlowId.java
@@ -6,8 +6,8 @@ package de.digitalcollections.flusswerk.engine.model;
  */
 public interface HasFlowId {
 
-  long getFlowId();
+  String getFlowId();
 
-  void setFlowId(long flowId);
+  void setFlowId(String flowId);
 
 }

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/HasFlowId.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/HasFlowId.java
@@ -1,0 +1,13 @@
+package de.digitalcollections.flusswerk.engine.model;
+
+/**
+ * Tagging interface for all {@link Message} implementations that allow the propagation of
+ * flow  ids from one workflow job to another, enabling Flusswerk to automatically set these.
+ */
+public interface HasFlowId {
+
+  long getFlowId();
+
+  void setFlowId(long flowId);
+
+}

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/Job.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/Job.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class Job<M, R, W> {
 
@@ -15,10 +16,17 @@ public class Job<M, R, W> {
 
   private Collection<Message> result;
 
+  private boolean propagateFlowIds;
+
   public Job(M message) {
     this.message = message;
     this.dataRead = null;
     this.dataTransformed = null;
+  }
+
+  public Job(M message, boolean propagateFlowIds) {
+    this(message);
+    this.propagateFlowIds = propagateFlowIds;
   }
 
   public void read(Function<M, R> reader) {
@@ -45,6 +53,12 @@ public class Job<M, R, W> {
   public Collection<Message> getResult() {
     if (result == null) {
       return Collections.emptyList();
+    }
+    if (propagateFlowIds) {
+      FlowMessage flowMessage = (FlowMessage) message;
+      for (Message message : result) {
+        ((HasFlowId) message).setFlowId(flowMessage.getFlowId());
+      }
     }
     return result;
   }

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilderTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilderTest.java
@@ -104,7 +104,7 @@ class FlowBuilderTest {
         .propagateFlowIds(true)
         .build();
 
-    FlowMessage incomingMessage = new FlowMessage("123", 42);
+    FlowMessage incomingMessage = new FlowMessage("123", "flow-42");
     FlowMessage outgoingMessage =  flow.process(incomingMessage).stream()
                                      .map(FlowMessage.class::cast)
                                      .findFirst()

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/jackson/FlowMessageMixinTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/jackson/FlowMessageMixinTest.java
@@ -31,7 +31,7 @@ class FlowMessageMixinTest {
   @Test
   @DisplayName("Deserialization should ignore unknown fields")
   void shouldIgnoreUnknownFields() throws IOException {
-    FlowMessage message = new FlowMessage("abc123", 3000);
+    FlowMessage message = new FlowMessage("abc123", "flow-3000");
     String json = objectMapper.writeValueAsString(message);
     json = json.substring(0, json.length() - 1) + ", \"stupidField\": 0}";
     FlowMessage restored = objectMapper.readValue(json, FlowMessage.class);
@@ -41,7 +41,7 @@ class FlowMessageMixinTest {
   @Test
   @DisplayName("Should serialize Envelope.retries")
   void shouldSerializeRetries() throws JsonProcessingException {
-    FlowMessage message = new FlowMessage("abc123", 3000);
+    FlowMessage message = new FlowMessage("abc123", "flow-3000");
     message.getEnvelope().setRetries(42);
     assertThat(objectMapper.writeValueAsString(message)).contains("42");
   }
@@ -49,7 +49,7 @@ class FlowMessageMixinTest {
   @Test
   @DisplayName("Should deserialize Envelope.retries")
   void shouldDeserializeRetries() throws IOException {
-    FlowMessage message = new FlowMessage("abc123", 3000);
+    FlowMessage message = new FlowMessage("abc123", "flow-3000");
     message.getEnvelope().setRetries(42);
     Message deserialized = objectMapper.readValue(objectMapper.writeValueAsString(message), FlowMessage.class);
     assertThat(deserialized.getEnvelope().getRetries()).isEqualTo(42);
@@ -58,7 +58,7 @@ class FlowMessageMixinTest {
   @Test
   @DisplayName("Should serialize and deserialize arbitrary values")
   void shouldSerializeAndDeserializeArbitraryValues() throws IOException {
-    FlowMessage message = new FlowMessage("abc123", 3000);
+    FlowMessage message = new FlowMessage("abc123", "flow-3000");
     message.put("purpose of life", "42");
     String json = objectMapper.writeValueAsString(message);
     FlowMessage deserialized = objectMapper.readValue(json, FlowMessage.class);

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/jackson/FlowMessageMixinTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/jackson/FlowMessageMixinTest.java
@@ -1,0 +1,68 @@
+package de.digitalcollections.flusswerk.engine.jackson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import de.digitalcollections.flusswerk.engine.model.FlowMessage;
+import de.digitalcollections.flusswerk.engine.model.Envelope;
+import de.digitalcollections.flusswerk.engine.model.Message;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FlowMessageMixinTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper()
+        .addMixIn(Message.class, FlowMessageMixin.class)
+        .addMixIn(Envelope.class, EnvelopeMixin.class)
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .enable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS);
+  }
+
+  @Test
+  @DisplayName("Deserialization should ignore unknown fields")
+  void shouldIgnoreUnknownFields() throws IOException {
+    FlowMessage message = new FlowMessage("abc123", 3000);
+    String json = objectMapper.writeValueAsString(message);
+    json = json.substring(0, json.length() - 1) + ", \"stupidField\": 0}";
+    FlowMessage restored = objectMapper.readValue(json, FlowMessage.class);
+    assertThat(message.getId()).isEqualTo(restored.getId());
+  }
+
+  @Test
+  @DisplayName("Should serialize Envelope.retries")
+  void shouldSerializeRetries() throws JsonProcessingException {
+    FlowMessage message = new FlowMessage("abc123", 3000);
+    message.getEnvelope().setRetries(42);
+    assertThat(objectMapper.writeValueAsString(message)).contains("42");
+  }
+
+  @Test
+  @DisplayName("Should deserialize Envelope.retries")
+  void shouldDeserializeRetries() throws IOException {
+    FlowMessage message = new FlowMessage("abc123", 3000);
+    message.getEnvelope().setRetries(42);
+    Message deserialized = objectMapper.readValue(objectMapper.writeValueAsString(message), FlowMessage.class);
+    assertThat(deserialized.getEnvelope().getRetries()).isEqualTo(42);
+  }
+
+  @Test
+  @DisplayName("Should serialize and deserialize arbitrary values")
+  void shouldSerializeAndDeserializeArbitraryValues() throws IOException {
+    FlowMessage message = new FlowMessage("abc123", 3000);
+    message.put("purpose of life", "42");
+    String json = objectMapper.writeValueAsString(message);
+    FlowMessage deserialized = objectMapper.readValue(json, FlowMessage.class);
+    assertThat(deserialized.get("purpose of life")).isEqualTo("42");
+  }
+
+}

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/model/JobTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/model/JobTest.java
@@ -2,12 +2,16 @@ package de.digitalcollections.flusswerk.engine.model;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 class JobTest {
 
@@ -39,6 +43,10 @@ class JobTest {
       called = true;
       return null;
     }
+  }
+
+  private Supplier<RuntimeException> exception(String message) {
+    return () -> new RuntimeException(message);
   }
 
   @BeforeEach
@@ -82,4 +90,24 @@ class JobTest {
             result -> assertThat(assertThat(((DefaultMessage) result).get("message")).isEqualTo(message.toUpperCase()))
     );
   }
+
+  @Test
+  @DisplayName("Should propagate flow ids")
+  void propagateFlowIds() {
+    FlowMessage incomingMessage = new FlowMessage("12345", 42);
+    Job<FlowMessage, String, String> job = new Job<>(incomingMessage, true);
+    job.read(Message::getId);
+    job.transform(Function.identity());
+    job.write((Function<String, Collection<Message>>) s -> Collections.singleton(new FlowMessage(s)));
+
+    FlowMessage outgoingMessage = job.getResult().stream()
+                                     .map(FlowMessage.class::cast)
+                                     .findFirst()
+                                     .orElseThrow(() -> new RuntimeException("No messages found."));
+
+     assertThat(outgoingMessage.getFlowId())
+        .isEqualTo(incomingMessage.getFlowId());
+  }
+
 }
+

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/model/JobTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/model/JobTest.java
@@ -2,16 +2,13 @@ package de.digitalcollections.flusswerk.engine.model;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 class JobTest {
 
@@ -94,7 +91,7 @@ class JobTest {
   @Test
   @DisplayName("Should propagate flow ids")
   void propagateFlowIds() {
-    FlowMessage incomingMessage = new FlowMessage("12345", 42);
+    FlowMessage incomingMessage = new FlowMessage("12345", "flow-42");
     Job<FlowMessage, String, String> job = new Job<>(incomingMessage, true);
     job.read(Message::getId);
     job.transform(Function.identity());


### PR DESCRIPTION
For more complex setups it is useful to track the processing of one object between different workflow steps. Flusswerk uses the concept of FlowIds to do so. This PR adds automatic propagation from Incoming to Outgoing messages.