### PR TITLE
CI: Introduce GitLab CI setup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,23 @@
+include: "https://raw.githubusercontent.com/dbmdz/development/master/ci/.gitlab-ci-base.yml"
+
+services:
+  - docker:dind
+
+variables:
+  DOCKER_HOST: tcp://docker:2375/
+
+.integration_tests:
+  script:
+    - docker-compose up -d
+    - mvn clean install
+    - mvn -B --projects integration -Pintegration surefire:test
+  stage: test
+
+integration_tests:
+  extends: .integration_tests
+
+integration_tests:openjdk11:
+  extends: .integration_tests
+  image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK11"
+  variables:
+    JAVA_HOME: "/usr/lib/jvm/java-11-openjdk-amd64"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,8 @@ variables:
     - mvn clean install
     - mvn -B --projects integration -Pintegration -Dspring.profiles.active=$MAVEN_ACTIVE_PROFILE surefire:test
   stage: test
+  variables:
+    RABBIT_HOST: docker
 
 integration_tests:
   extends: .integration_tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   script:
     - docker-compose up -d
     - mvn clean install
-    - mvn -B --projects integration -Pintegration surefire:test
+    - mvn -B --projects integration -Pintegration -Dspring.profiles.active=$MAVEN_ACTIVE_PROFILE surefire:test
   stage: test
 
 integration_tests:

--- a/examples/src/main/resources/application.yml
+++ b/examples/src/main/resources/application.yml
@@ -16,3 +16,10 @@ messageBroker:
   queues:
     read: someInputQueue
     write: someOutputQueue
+
+---
+
+spring:
+  profiles: ci
+  rabbitmq:
+    host: docker


### PR DESCRIPTION
This PR uses our (@dbmdz) generic GitLab CI configuration.

Additionally, the CI configuration was extended to support Docker-in-Docker (*dind*) to run integration tests. 

For executing all integration tests, the `docker-compose` setup is booted and exports a rabbitmq server. 

Our *dind* setup does not allow us to communicate on `localhost` hostname, so `docker` must be set as hostname for accessing the rabbitmq server. Furthermore, a new spring boot profile (named `ci`) was introduced that also sets this specific hostname.