### PR TITLE
CI: Fix uploading of artefacts to GitHub

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,12 @@
 include: "https://raw.githubusercontent.com/dbmdz/development/master/ci/.gitlab-ci-base.yml"
 
+cache:
+  key: "$CI_COMMIT_SHA"
+  paths:
+    - engine/target/
+    - examples/target/
+    - integration/target/
+
 services:
   - docker:dind
 


### PR DESCRIPTION
With this PR, uploading of artefacts to GitHub for a (pre-)release should work now.

The generic GitLab CI Configuration only caches all files located under `./target`. But `flusswerk` don't have a global `./target` folder. Instead, the `.jar` files are located under:

```bash
./bdd/target/dc-flusswerk-bdd-2.3.0-SNAPSHOT.jar
./engine/target/dc-flusswerk-engine-2.3.0.jar
./engine/target/dc-flusswerk-engine-2.3.0-javadoc.jar
./engine/target/dc-flusswerk-engine-2.3.0-sources.jar
./examples/target/dc-flusswerk-examples-2.3.0.jar
./examples/target/dc-flusswerk-examples-2.3.0-javadoc.jar
./examples/target/dc-flusswerk-examples-2.3.0-sources.jar
./integration/target/dc-flusswerk-integration-2.3.0.jar
```

This PR add these paths to the GitLab CI configuration. Uploading artefacts to GitHub should then work for (pre-)releases :)