### PR TITLE
CI: enable integration tests on OpenJDK 12

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,3 +30,10 @@ integration_tests:openjdk11:
   image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK11"
   variables:
     JAVA_HOME: "/usr/lib/jvm/java-11-openjdk-amd64"
+
+integration_tests:openjdk12:
+  extends: .integration_tests
+  image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK12"
+  only:
+    variables:
+      - $USE_OPENJDK12


### PR DESCRIPTION
This PR adds OpenJDK 12 to the build matrix for integration tests.

---

**Note**: We are testing OpenJDK 12 internally. Whenever the CI image for OpenJDK 12 is rock-solid, the `only.variables==$USE_OPENJDK12` check can be removed.