### PR TITLE
Add functional interface for easy custom ProcessReports

### DIFF
--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/reporting/ReportFunction.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/reporting/ReportFunction.java
@@ -1,0 +1,34 @@
+package de.digitalcollections.flusswerk.engine.reporting;
+
+import de.digitalcollections.flusswerk.engine.exceptions.FinallyFailedProcessException;
+import de.digitalcollections.flusswerk.engine.model.Message;
+
+/**
+ * Functional interface to easily create custom reporters with a lambda.
+ */
+@FunctionalInterface
+public interface ReportFunction extends ProcessReport {
+  enum ReportType { SUCCESS, FAIL, FAIL_AFTER_MAX_RETRIES, REJECT };
+
+  void report(ReportType type, Message msg, Exception e);
+
+  @Override
+  default void reportSuccess(Message msg) {
+    this.report(ReportType.SUCCESS, msg, null);
+  }
+
+  @Override
+  default void reportFail(Message msg, FinallyFailedProcessException e) {
+    this.report(ReportType.FAIL, msg, e);
+  }
+
+  @Override
+  default void reportFailAfterMaxRetries(Message msg, Exception e) {
+    this.report(ReportType.FAIL_AFTER_MAX_RETRIES, msg, e);
+  }
+
+  @Override
+  default void reportReject(Message msg, Exception e) {
+    this.report(ReportType.REJECT, msg, e);
+  }
+}


### PR DESCRIPTION
This PR adds a new `ReportFunction` interface that allows defining a custom `ProcessReport` via an anonymous function:


```java
// Dummy reporter
ReportFunction nopReportFn = (type, msg, exc) -> {};

// Reporter that only logs failures
ReportFunction reportFn = (type, msg, exc) -> {
  switch (type) {
    case ReportType.FAIL:
    case ReportType.FAIL_AFTER_MAX_RETRIES:
      System.err.println("Message failed!");
    default:
      // NOP
  }
}
```