### PR TITLE
Change INFO logging outside of reporter to DEBUG

### DIFF
--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/messagebroker/RabbitConnection.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/messagebroker/RabbitConnection.java
@@ -45,12 +45,12 @@ class RabbitConnection {
     while (connectionIsFailing) {
       List<Address> addresses = config.getAddresses();
       try {
-        LOGGER.info("Waiting for connection to {} ...", addresses);
+        LOGGER.debug("Waiting for connection to {} ...", addresses);
         Connection connection = factory.newConnection(addresses);
         channel = connection.createChannel();
         channel.basicRecover(true);
         connectionIsFailing = false;
-        LOGGER.info("Connected to {}", addresses);
+        LOGGER.debug("Connected to {}", addresses);
       } catch (IOException | TimeoutException e) {
         LOGGER.debug("Could not connect to {}", addresses, e);
         try {

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/EngineTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/EngineTest.java
@@ -88,7 +88,7 @@ class EngineTest {
     EngineStats engineStats = engine.getStats();
     boolean shouldWait = engineStats.getAvailableWorkers() > 0;
     while (shouldWait) {
-      LOGGER.info("Waiting for workers to get busy: {} active, {} free after {} ms", engineStats.getActiveWorkers(), engineStats.getAvailableWorkers(), millisecondsWaited);
+      LOGGER.debug("Waiting for workers to get busy: {} active, {} free after {} ms", engineStats.getActiveWorkers(), engineStats.getAvailableWorkers(), millisecondsWaited);
       millisecondsWaited += 100;
       TimeUnit.MILLISECONDS.sleep(100);
       engineStats = engine.getStats();


### PR DESCRIPTION
This is in accordance with the new WIP MDZ logging guidelines that stipulate that backing libraries should not log at the `INFO` level.