### PR TITLE
CI: Minor fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ cache:
     - integration/target/
 
 services:
-  - docker:dind
+  - "$DIND_IMAGE"
 
 variables:
   DOCKER_HOST: tcp://docker:2375/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,8 +25,6 @@ variables:
 integration_tests:openjdk11:
   extends: .integration_tests
   image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK11"
-  variables:
-    JAVA_HOME: "/usr/lib/jvm/java-11-openjdk-amd64"
 
 integration_tests:openjdk12:
   extends: .integration_tests


### PR DESCRIPTION
Hi,

this PR introduces two minor changes in the CI configuration:

* To internally workaround this [Docker-in-Docker/GItLab](https://gitlab.com/charts/gitlab/issues/478) bug, we make the Docker-in-Docker image configurable. Internally, we use a *18.09.7-dind* tagged release of the `dind` image to mitigate failing builds (as mentioned in that issue)
* Setting `JAVA_HOME` is no longer needed, because this is already done in our CI `Dockerfile`