### PR TITLE
Fix log level for connection errors

### DIFF
--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/messagebroker/RabbitConnection.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/messagebroker/RabbitConnection.java
@@ -52,7 +52,7 @@ class RabbitConnection {
         connectionIsFailing = false;
         LOGGER.debug("Connected to {}", addresses);
       } catch (IOException | TimeoutException e) {
-        LOGGER.debug("Could not connect to {}", addresses, e);
+        LOGGER.warn("Could not connect to {}: {} {}", addresses, e.getClass().getSimpleName(), e.getMessage(), e);
         try {
           TimeUnit.SECONDS.sleep(RETRY_INTERVAL);
         } catch (InterruptedException e1) {


### PR DESCRIPTION
When connection to RabbitMQ was not possible, the log messages were only at level debug,