### PR TITLE
Add simpler way to implement custom message types

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,13 +261,48 @@ would be represented as
 
 ### How to use a custom message implementation
 
-The default message implementation `DefaultMessage` allows to set arbitrary key-value-pairs of type `String`. To use a custom message implementation it has to be registered:
+If your data is more than just an id and a few `String` key-value-pairs it is recommended to use your own message implementation:
+
+```java
+public class ExampleMessage extends FlusswerkMessage<Integer> {
+
+  private int priority;
+
+  private String[] tags;
+
+  public PowerMessage(Integer id, int priority, String... tags) {
+    this.priority = priority;
+    this.tags = requireNonNullElseGet(tags, () -> new String[]{});
+  }
+
+  public int getPriority() {
+    return priority;
+  }
+
+  public String[] getTags() {
+    return tags;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("ExampleMessage{%d, %d, %s}", id, priority, Arrays.toString(tags));
+  }
+}
+```
+
+The custom message implementation needs a Jackson Mixin that needs to be registered with the `MessageBroker`:
+
+```java
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_EMPTY)
+public interface ExampleMessageMixin {}
+```
 
 ```java
 class Application {
   public static void main(String[] args) {
     MessageBroker messageBroker = new MessageBrokerBuilder()
-        .messageMapping(CustomMessage.class, CustomMessageMixin.class)
+        .messageMapping(ExampleMessage.class, ExampleMessageMixin.class)
         .build();
     /* ... */
   }

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/DefaultMessage.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/DefaultMessage.java
@@ -5,11 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.HashMap;
 import java.util.Map;
 
-public class DefaultMessage implements Message<String> {
-
-  private Envelope envelope;
-
-  private String id;
+public class DefaultMessage extends FlusswerkMessage<String> {
 
   private Map<String, String> data;
 
@@ -18,14 +14,8 @@ public class DefaultMessage implements Message<String> {
   }
 
   public DefaultMessage(String id) {
-    this.envelope = new Envelope();
+    super(id);
     this.data = new HashMap<>();
-    this.id = id;
-  }
-
-  @Override
-  public Envelope getEnvelope() {
-    return envelope;
   }
 
   public Map<String, String> getData() {
@@ -55,12 +45,7 @@ public class DefaultMessage implements Message<String> {
   }
 
   @Override
-  public String getId() {
-    return id;
-  }
-
-  @Override
   public String toString() {
-    return "Message{id=" + id + ", envelope=" + envelope + ", data=" + data + "}";
+    return "Message{id=" + identifier + ", envelope=" + getEnvelope() + ", data=" + data + "}";
   }
 }

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/DefaultMessage.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/DefaultMessage.java
@@ -46,6 +46,6 @@ public class DefaultMessage extends FlusswerkMessage<String> {
 
   @Override
   public String toString() {
-    return "Message{id=" + identifier + ", envelope=" + getEnvelope() + ", data=" + data + "}";
+    return "Message{id=" + id + ", envelope=" + getEnvelope() + ", data=" + data + "}";
   }
 }

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/FlusswerkMessage.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/FlusswerkMessage.java
@@ -9,16 +9,16 @@ public abstract class FlusswerkMessage<T> implements Message<T> {
 
   private Envelope envelope;
 
-  protected T identifier;
+  protected T id;
 
   public FlusswerkMessage() {
     this.envelope = new Envelope();
-    this.identifier = null;
+    this.id = null;
   }
 
-  public FlusswerkMessage(T identifier) {
+  public FlusswerkMessage(T id) {
     this.envelope = new Envelope();
-    this.identifier = identifier;
+    this.id = id;
   }
 
   @Override
@@ -28,6 +28,6 @@ public abstract class FlusswerkMessage<T> implements Message<T> {
 
   @Override
   public T getId() {
-    return identifier;
+    return id;
   }
 }

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/FlusswerkMessage.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/FlusswerkMessage.java
@@ -1,0 +1,33 @@
+package de.digitalcollections.flusswerk.engine.model;
+
+/**
+ * Base class for implementations of Message.
+ *
+ * @param <T> The data type used for the identifier.
+ */
+public abstract class FlusswerkMessage<T> implements Message<T> {
+
+  private Envelope envelope;
+
+  protected T identifier;
+
+  public FlusswerkMessage() {
+    this.envelope = new Envelope();
+    this.identifier = null;
+  }
+
+  public FlusswerkMessage(T identifier) {
+    this.envelope = new Envelope();
+    this.identifier = identifier;
+  }
+
+  @Override
+  public Envelope getEnvelope() {
+    return envelope;
+  }
+
+  @Override
+  public T getId() {
+    return identifier;
+  }
+}


### PR DESCRIPTION
All message implementations have to define and correctly initialize an
envelope field. This is not only prone to errors, but also dependent on
the internals of Flusswerk. An abstract base class encapsulates now the
technical specifics so that all implementations of the `Message` interface
now can focus on domain specific logic alone.