### PR TITLE
Add simplified and more flexible custom message types

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,20 @@ public class ExampleMessage extends FlusswerkMessage<Integer> {
 }
 ```
 
-The custom message implementation needs a Jackson Mixin that needs to be registered with the `MessageBroker`:
+The custom message implementation needs to be registered with the MessageBrokerBuilder:
+
+```java
+class Application {
+  public static void main(String[] args) {
+    MessageBroker messageBroker = new MessageBrokerBuilder()
+        .useMessageClass(ExampleMessage.class)
+        .build();
+    /* ... */
+  }
+}
+```
+
+For a more fine grained serialization control, a custom Jackson mixin is also possible:
 
 ```java
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -302,7 +315,7 @@ public interface ExampleMessageMixin {}
 class Application {
   public static void main(String[] args) {
     MessageBroker messageBroker = new MessageBrokerBuilder()
-        .messageMapping(ExampleMessage.class, ExampleMessageMixin.class)
+        .useMessageClass(ExampleMessage.class, ExampleMessageMixin.class)
         .build();
     /* ... */
   }

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/jackson/DefaultMixin.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/jackson/DefaultMixin.java
@@ -6,4 +6,4 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_EMPTY)
-public interface FlowMessageMixin {}
+public interface DefaultMixin {}

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/messagebroker/MessageBrokerBuilder.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/messagebroker/MessageBrokerBuilder.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.databind.Module;
 import de.digitalcollections.flusswerk.engine.exceptions.WorkflowSetupException;
+import de.digitalcollections.flusswerk.engine.jackson.DefaultMixin;
 import de.digitalcollections.flusswerk.engine.jackson.SingleClassModule;
 import de.digitalcollections.flusswerk.engine.model.Message;
 import java.io.IOException;
@@ -132,11 +133,38 @@ public class MessageBrokerBuilder {
    * @param messageClass The custom message implementation you want to use.
    * @param messageMixin The mixin to serialize/deserialize this message.
    * @return This {@link MessageBrokerBuilder} instance to chain configuration calls.
+   * @deprecated Replaced by {@link #useMessageClass(Class)} and {@link #useMessageClass(Class,
+   *     Class)}
    */
+  @Deprecated
   public MessageBrokerBuilder messageMapping(
       Class<? extends Message<?>> messageClass, Class<?> messageMixin) {
-    config.addJacksonModule(new SingleClassModule(messageClass, messageMixin));
-    config.setMessageClass(messageClass);
+    return useMessageClass(messageClass, messageMixin);
+  }
+
+  /**
+   * Registers a custom {@link Message} implementation (usually a subclass of {@link
+   * de.digitalcollections.flusswerk.engine.model.FlusswerkMessage}).
+   *
+   * @param cls The custom message implementation you want to use.
+   * @return This {@link MessageBrokerBuilder} instance to chain configuration calls.
+   */
+  public MessageBrokerBuilder useMessageClass(Class<? extends Message<?>> cls) {
+    return useMessageClass(cls, DefaultMixin.class);
+  }
+
+  /**
+   * Registers a custom {@link Message} implementation (usually a subclass of {@link
+   * de.digitalcollections.flusswerk.engine.model.FlusswerkMessage}) and custom Jackson mixin for
+   * more fine grained serialization control.
+   *
+   * @param cls The custom message implementation you want to use.
+   * @param mixin The Jackson mixin to use
+   * @return This {@link MessageBrokerBuilder} instance to chain configuration calls.
+   */
+  public MessageBrokerBuilder useMessageClass(Class<? extends Message<?>> cls, Class<?> mixin) {
+    config.addJacksonModule(new SingleClassModule(cls, mixin));
+    config.setMessageClass(cls);
     return this;
   }
 

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/messagebroker/RabbitConnection.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/messagebroker/RabbitConnection.java
@@ -52,7 +52,12 @@ class RabbitConnection {
         connectionIsFailing = false;
         LOGGER.debug("Connected to {}", addresses);
       } catch (IOException | TimeoutException e) {
-        LOGGER.warn("Could not connect to {}: {} {}", addresses, e.getClass().getSimpleName(), e.getMessage(), e);
+        LOGGER.warn(
+            "Could not connect to {}: {} {}",
+            addresses,
+            e.getClass().getSimpleName(),
+            e.getMessage(),
+            e);
         try {
           TimeUnit.SECONDS.sleep(RETRY_INTERVAL);
         } catch (InterruptedException e1) {

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/jackson/DefaultMixinTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/jackson/DefaultMixinTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class FlowMessageMixinTest {
+class DefaultMixinTest {
 
   private ObjectMapper objectMapper;
 
@@ -22,7 +22,7 @@ class FlowMessageMixinTest {
   void setUp() {
     objectMapper =
         new ObjectMapper()
-            .addMixIn(Message.class, FlowMessageMixin.class)
+            .addMixIn(Message.class, DefaultMixin.class)
             .addMixIn(Envelope.class, EnvelopeMixin.class)
             .registerModule(new JavaTimeModule())
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/spring-boot-example/src/main/java/de/digitalcollections/flusswerk/spring/boot/example/config/FlusswerkConfig.java
+++ b/spring-boot-example/src/main/java/de/digitalcollections/flusswerk/spring/boot/example/config/FlusswerkConfig.java
@@ -7,8 +7,7 @@ import de.digitalcollections.flusswerk.engine.reporting.ProcessReport;
 import de.digitalcollections.flusswerk.spring.boot.example.ComposePerfectGreeting;
 import de.digitalcollections.flusswerk.spring.boot.example.FancyConsoleProcessReport;
 import de.digitalcollections.flusswerk.spring.boot.example.model.Greeting;
-import de.digitalcollections.flusswerk.spring.boot.example.model.GreetingMixin;
-import de.digitalcollections.flusswerk.spring.boot.starter.MessageMapping;
+import de.digitalcollections.flusswerk.spring.boot.starter.MessageImplementation;
 import java.util.function.Consumer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,8 +16,8 @@ import org.springframework.context.annotation.Configuration;
 public class FlusswerkConfig {
 
   @Bean
-  MessageMapping<Greeting> messageMapping() {
-    return new MessageMapping<>(Greeting.class, GreetingMixin.class);
+  MessageImplementation messageImplementation() {
+    return new MessageImplementation(Greeting.class);
   }
 
   @Bean

--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/MessageImplementation.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/MessageImplementation.java
@@ -1,0 +1,50 @@
+package de.digitalcollections.flusswerk.spring.boot.starter;
+
+import static java.util.Objects.requireNonNull;
+
+import de.digitalcollections.flusswerk.engine.model.Message;
+
+/** Register a custom message implementation via Spring. */
+public class MessageImplementation {
+
+  private Class<? extends Message<?>> messageClass;
+
+  private Class<?> mixin;
+
+  /**
+   * Provide a custom {@link Message} implmentation with default serialization and deserialization
+   * settings.
+   *
+   * @param cls the custom {@link Message} implementation
+   */
+  public MessageImplementation(Class<? extends Message<?>> cls) {
+    this.messageClass = requireNonNull(cls);
+  }
+
+  /**
+   * Provide a custom {@link Message} implmentation with custom serialization and deserialization
+   * settings.
+   *
+   * @param cls custom {@link Message} implementation
+   * @param mixin custom Jackson mixin for specific serialization and deserialization settings
+   */
+  public MessageImplementation(Class<Message<?>> cls, Class<?> mixin) {
+    this.messageClass = requireNonNull(cls);
+    this.mixin = requireNonNull(mixin);
+  }
+
+  /** @return the class of the custom message implementation */
+  public Class<? extends Message<?>> getMessageClass() {
+    return messageClass;
+  }
+
+  /** @return the custom Jackson mixin for the {@link Message} implementation */
+  public Class<?> getMixin() {
+    return mixin;
+  }
+
+  /** @return true, if there is also a Jackson mixin for the message class */
+  public boolean hasMixin() {
+    return this.mixin != null;
+  }
+}

--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/MessageMapping.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/MessageMapping.java
@@ -7,7 +7,9 @@ import de.digitalcollections.flusswerk.engine.model.Message;
  * registration as a Spring bean.
  *
  * @param <T> The message class
+ * @deprecated Use the easier and more flexible {@link MessageImplementation} instead
  */
+@Deprecated
 public class MessageMapping<T extends Message<?>> {
 
   private Class<T> messageClass;


### PR DESCRIPTION
In earlier versions any custom message implementation needed a Jackson mixin to configure serialization/deserialization. In most cases this is copy and paste of the same mixin. The new API does not require custom mixins anymore while keeping the possibility for fine grained control in case it is needed.