### PR TITLE
Add priority queues to Spring Boot Starter

### DIFF
--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/messagebroker/RabbitConnection.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/messagebroker/RabbitConnection.java
@@ -52,7 +52,12 @@ class RabbitConnection {
         connectionIsFailing = false;
         LOGGER.debug("Connected to {}", addresses);
       } catch (IOException | TimeoutException e) {
-        LOGGER.warn("Could not connect to {}: {} {}", addresses, e.getClass().getSimpleName(), e.getMessage(), e);
+        LOGGER.warn(
+            "Could not connect to {}: {} {}",
+            addresses,
+            e.getClass().getSimpleName(),
+            e.getMessage(),
+            e);
         try {
           TimeUnit.SECONDS.sleep(RETRY_INTERVAL);
         } catch (InterruptedException e1) {

--- a/spring-boot-starter-flusswerk/pom.xml
+++ b/spring-boot-starter-flusswerk/pom.xml
@@ -42,6 +42,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+      <version>${version.spring-boot}</version>
+    </dependency>
   </dependencies>
 
 

--- a/spring-boot-starter-flusswerk/pom.xml
+++ b/spring-boot-starter-flusswerk/pom.xml
@@ -35,6 +35,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${version.junit}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
     </dependency>

--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfiguration.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfiguration.java
@@ -8,13 +8,13 @@ import de.digitalcollections.flusswerk.engine.model.Message;
 import de.digitalcollections.flusswerk.engine.reporting.ProcessReport;
 import java.io.IOException;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /** Spring configuration to provide beans for{@link MessageBroker} and {@link Engine}. */
 @Configuration
-@EnableConfigurationProperties(FlusswerkProperties.class)
+@Import(FlusswerkPropertiesConfiguration.class)
 public class FlusswerkConfiguration {
 
   /**
@@ -41,7 +41,7 @@ public class FlusswerkConfiguration {
         mapping -> builder.messageMapping(mapping.getMessageClass(), mapping.getMixin()));
 
     if (routing.getReadFrom() != null) {
-      builder.readFrom(routing.getReadFrom() + ".priority", routing.getReadFrom());
+      builder.readFrom(routing.getReadFrom());
     }
     if (routing.getWriteTo() != null) {
       builder.writeTo(routing.getWriteTo());

--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkProperties.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkProperties.java
@@ -113,7 +113,7 @@ public class FlusswerkProperties {
 
     @NotBlank private String exchange;
 
-    private String readFrom;
+    private String[] readFrom;
 
     private String writeTo;
 
@@ -122,7 +122,7 @@ public class FlusswerkProperties {
      * @param readFrom The queue to read from (optional).
      * @param writeTo The topic to send to per default (optional).
      */
-    public Routing(@NotBlank String exchange, String readFrom, String writeTo) {
+    public Routing(@NotBlank String exchange, String[] readFrom, String writeTo) {
       this.exchange = exchange;
       this.readFrom = readFrom;
       this.writeTo = writeTo;
@@ -134,7 +134,7 @@ public class FlusswerkProperties {
     }
 
     /** @return The queue to read from (optional). */
-    public String getReadFrom() {
+    public String[] getReadFrom() {
       return readFrom;
     }
 
@@ -147,7 +147,7 @@ public class FlusswerkProperties {
     public String toString() {
       return StringRepresentation.of(Routing.class)
           .property("exchange", exchange)
-          .property("readFrom", readFrom)
+          .property("readFrom", String.join(",", readFrom))
           .property("writeTo", writeTo)
           .toString();
     }

--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkPropertiesConfiguration.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkPropertiesConfiguration.java
@@ -1,0 +1,9 @@
+package de.digitalcollections.flusswerk.spring.boot.starter;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+/**
+ * Separate config class for reading configuration properties to enable automated testing.
+ */
+@EnableConfigurationProperties(FlusswerkProperties.class)
+public class FlusswerkPropertiesConfiguration {}

--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkPropertiesConfiguration.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkPropertiesConfiguration.java
@@ -2,8 +2,6 @@ package de.digitalcollections.flusswerk.spring.boot.starter;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
-/**
- * Separate config class for reading configuration properties to enable automated testing.
- */
+/** Separate config class for reading configuration properties to enable automated testing. */
 @EnableConfigurationProperties(FlusswerkProperties.class)
 public class FlusswerkPropertiesConfiguration {}

--- a/spring-boot-starter-flusswerk/src/test/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkPropertiesTest.java
+++ b/spring-boot-starter-flusswerk/src/test/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkPropertiesTest.java
@@ -12,8 +12,7 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration(classes = FlusswerkPropertiesConfiguration.class)
 public class FlusswerkPropertiesTest {
 
-  @Autowired
-  private FlusswerkProperties properties;
+  @Autowired private FlusswerkProperties properties;
 
   @Test
   @DisplayName("Values of FlusswerkProperties.Processing are all set")
@@ -25,7 +24,6 @@ public class FlusswerkPropertiesTest {
 
   @Test
   @DisplayName("Values of FlusswerkProperties.Connection are all set")
-
   public void valuesOfConnection() {
     assertThat(properties.getConnection())
         .hasFieldOrPropertyWithValue("connectTo", "my.rabbit.example.com:5672")
@@ -39,8 +37,7 @@ public class FlusswerkPropertiesTest {
   public void valuesOfRouting() {
     assertThat(properties.getRouting())
         .hasFieldOrPropertyWithValue("exchange", "my.exchange")
-        .hasFieldOrPropertyWithValue("readFrom", new String[]{ "first", "second" })
+        .hasFieldOrPropertyWithValue("readFrom", new String[] {"first", "second"})
         .hasFieldOrPropertyWithValue("writeTo", "defalt.queue.to.write.to");
   }
-
 }

--- a/spring-boot-starter-flusswerk/src/test/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkPropertiesTest.java
+++ b/spring-boot-starter-flusswerk/src/test/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkPropertiesTest.java
@@ -1,0 +1,46 @@
+package de.digitalcollections.flusswerk.spring.boot.starter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(classes = FlusswerkPropertiesConfiguration.class)
+public class FlusswerkPropertiesTest {
+
+  @Autowired
+  private FlusswerkProperties properties;
+
+  @Test
+  @DisplayName("Values of FlusswerkProperties.Processing are all set")
+  public void valuesOfProcessing() {
+    assertThat(properties.getProcessing())
+        .hasFieldOrPropertyWithValue("maxRetries", 5)
+        .hasFieldOrPropertyWithValue("threads", 5);
+  }
+
+  @Test
+  @DisplayName("Values of FlusswerkProperties.Connection are all set")
+
+  public void valuesOfConnection() {
+    assertThat(properties.getConnection())
+        .hasFieldOrPropertyWithValue("connectTo", "my.rabbit.example.com:5672")
+        .hasFieldOrPropertyWithValue("virtualHost", "vh1")
+        .hasFieldOrPropertyWithValue("username", "guest")
+        .hasFieldOrPropertyWithValue("password", "guest");
+  }
+
+  @Test
+  @DisplayName("Values of FlusswerkProperties.Routing are all set")
+  public void valuesOfRouting() {
+    assertThat(properties.getRouting())
+        .hasFieldOrPropertyWithValue("exchange", "my.exchange")
+        .hasFieldOrPropertyWithValue("readFrom", new String[]{ "first", "second" })
+        .hasFieldOrPropertyWithValue("writeTo", "defalt.queue.to.write.to");
+  }
+
+}

--- a/spring-boot-starter-flusswerk/src/test/resources/application.yml
+++ b/spring-boot-starter-flusswerk/src/test/resources/application.yml
@@ -1,0 +1,15 @@
+flusswerk:
+  processing:
+    maxRetries: 5
+    threads: 5
+  connection:
+    connectTo: my.rabbit.example.com:5672
+    virtualHost: vh1
+    username: guest
+    password: guest
+  routing:
+    exchange: my.exchange
+    readFrom:
+      - first
+      - second
+    writeTo: defalt.queue.to.write.to


### PR DESCRIPTION
Flusswerk allows for a list of input queues, where the order defines the priority from which messages are read first. The Spring Boot Starter now provides the same configuration via `application.yml`.