### PR TITLE
Fix NPE with Spring Boot starter

### DIFF
--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfiguration.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfiguration.java
@@ -34,9 +34,12 @@ public class FlusswerkConfiguration {
             .username(connection.getUsername())
             .password(connection.getPassword())
             .exchange(routing.getExchange())
-            .virtualHost(connection.getVirtualHost())
             .maxRetries(processing.getMaxRetries())
             .connectTo(connection.getConnectTo());
+
+    if (connection.getVirtualHost() != null) {
+      builder.virtualHost(connection.getVirtualHost());
+    }
 
     messageImplementation.ifAvailable(
         impl -> {


### PR DESCRIPTION
The value for `virtualHost` can be `null` if the virtual host feature is not desired.