### PR TITLE
Fix optional arguments in application.yml

### DIFF
--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfiguration.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfiguration.java
@@ -31,36 +31,36 @@ public class FlusswerkConfiguration {
     FlusswerkProperties.Routing routing = flusswerkProperties.getRouting();
     final MessageBrokerBuilder builder = new MessageBrokerBuilder();
 
-    if (connection.getUsername() != null) {
+    if (isSet(connection.getUsername())) {
       builder.username(connection.getUsername());
     }
 
-    if (connection.getPassword() != null) {
+    if (isSet(connection.getPassword())) {
       builder.password(connection.getPassword());
     }
 
-    if (connection.getConnectTo() != null) {
+    if (isSet(connection.getConnectTo())) {
       builder.connectTo(connection.getConnectTo());
     } else {
       throw new IllegalArgumentException("connect-to is missing");
     }
 
-    if (connection.getVirtualHost() != null) {
+    if (isSet(connection.getVirtualHost())) {
       builder.virtualHost(connection.getVirtualHost());
     }
 
-    if (processing.getMaxRetries() != null) {
+    if (isSet(processing.getMaxRetries())) {
       builder.maxRetries(processing.getMaxRetries());
     }
 
-    if (routing.getExchange() != null) {
+    if (isSet(routing.getExchange())) {
       builder.exchange(routing.getExchange());
     }
 
-    if (routing.getReadFrom() != null) {
+    if (isSet(routing.getReadFrom())) {
       builder.readFrom(routing.getReadFrom());
     }
-    if (routing.getWriteTo() != null) {
+    if (isSet(routing.getWriteTo())) {
       builder.writeTo(routing.getWriteTo());
     }
 
@@ -110,4 +110,15 @@ public class FlusswerkConfiguration {
     ProcessReport processReport = processReportProvider.getIfAvailable();
     return new Engine(messageBroker, flow, threads, processReport);
   }
+
+  public static boolean isSet(Object value) {
+    if (value == null) {
+      return false;
+    }
+    if (value instanceof String) {
+      return !((String) value).matches("\\s*");
+    }
+    return true;
+  }
+
 }

--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfiguration.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfiguration.java
@@ -12,13 +12,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-/** Spring configuration to provide beans for{@link MessageBroker} and {@link Engine}. */
+/**
+ * Spring configuration to provide beans for{@link MessageBroker} and {@link Engine}.
+ */
 @Configuration
 @Import(FlusswerkPropertiesConfiguration.class)
 public class FlusswerkConfiguration {
 
   /**
-   * @param flusswerkProperties The external configuration from <code>application.yml</code>
+   * @param flusswerkProperties   The external configuration from <code>application.yml</code>
    * @param messageImplementation A custom {@link Message} implementation to use.
    * @return The message broker for this job.
    */
@@ -29,14 +31,40 @@ public class FlusswerkConfiguration {
     FlusswerkProperties.Connection connection = flusswerkProperties.getConnection();
     FlusswerkProperties.Processing processing = flusswerkProperties.getProcessing();
     FlusswerkProperties.Routing routing = flusswerkProperties.getRouting();
-    final MessageBrokerBuilder builder =
-        new MessageBrokerBuilder()
-            .username(connection.getUsername())
-            .password(connection.getPassword())
-            .exchange(routing.getExchange())
-            .virtualHost(connection.getVirtualHost())
-            .maxRetries(processing.getMaxRetries())
-            .connectTo(connection.getConnectTo());
+    final MessageBrokerBuilder builder = new MessageBrokerBuilder();
+
+    if (connection.getUsername() != null) {
+      builder.username(connection.getUsername());
+    }
+
+    if (connection.getPassword() != null) {
+      builder.password(connection.getPassword());
+    }
+
+    if (connection.getConnectTo() != null) {
+      builder.connectTo(connection.getConnectTo());
+    } else {
+      throw new IllegalArgumentException("connect-to is missing");
+    };
+
+    if (connection.getVirtualHost() != null) {
+      builder.virtualHost(connection.getVirtualHost());
+    }
+
+    if (processing.getMaxRetries() != null) {
+      builder.maxRetries(processing.getMaxRetries());
+    }
+
+    if (routing.getExchange() != null) {
+      builder.exchange(routing.getExchange());
+    }
+
+    if (routing.getReadFrom() != null) {
+      builder.readFrom(routing.getReadFrom());
+    }
+    if (routing.getWriteTo() != null) {
+      builder.writeTo(routing.getWriteTo());
+    }
 
     messageImplementation.ifAvailable(
         impl -> {
@@ -47,24 +75,19 @@ public class FlusswerkConfiguration {
           }
         });
 
-    if (routing.getReadFrom() != null) {
-      builder.readFrom(routing.getReadFrom());
-    }
-    if (routing.getWriteTo() != null) {
-      builder.writeTo(routing.getWriteTo());
-    }
+
     return builder.build();
   }
 
   /**
-   * @param messageBroker The messageBroker to use.
-   * @param flowProvider The flow to use (optional).
-   * @param flusswerkProperties The external configuration from <code>application.yml</code>.
+   * @param messageBroker         The messageBroker to use.
+   * @param flowProvider          The flow to use (optional).
+   * @param flusswerkProperties   The external configuration from <code>application.yml</code>.
    * @param processReportProvider A custom process report provider (optional).
-   * @param <I> The message's identifier type.
-   * @param <M> The used {@link Message} type
-   * @param <R> The type of the reader implementation
-   * @param <W> The type of the writer implementation
+   * @param <I>                   The message's identifier type.
+   * @param <M>                   The used {@link Message} type
+   * @param <R>                   The type of the reader implementation
+   * @param <W>                   The type of the writer implementation
    * @return The {@link Engine} used for this job.
    * @throws IOException If connection to RabbitMQ fails permanently.
    */
@@ -79,7 +102,14 @@ public class FlusswerkConfiguration {
     if (flow == null) {
       throw new RuntimeException("Missing flow definition. Please create a Flow bean.");
     }
-    int threads = flusswerkProperties.getProcessing().getThreads();
+
+    int threads;
+    if (flusswerkProperties.getProcessing().getThreads() != null) {
+      threads = flusswerkProperties.getProcessing().getThreads();
+    } else {
+      threads = 5;
+    }
+
     ProcessReport processReport = processReportProvider.getIfAvailable();
     return new Engine(messageBroker, flow, threads, processReport);
   }

--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfiguration.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfiguration.java
@@ -12,15 +12,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-/**
- * Spring configuration to provide beans for{@link MessageBroker} and {@link Engine}.
- */
+/** Spring configuration to provide beans for{@link MessageBroker} and {@link Engine}. */
 @Configuration
 @Import(FlusswerkPropertiesConfiguration.class)
 public class FlusswerkConfiguration {
 
   /**
-   * @param flusswerkProperties   The external configuration from <code>application.yml</code>
+   * @param flusswerkProperties The external configuration from <code>application.yml</code>
    * @param messageImplementation A custom {@link Message} implementation to use.
    * @return The message broker for this job.
    */
@@ -45,7 +43,7 @@ public class FlusswerkConfiguration {
       builder.connectTo(connection.getConnectTo());
     } else {
       throw new IllegalArgumentException("connect-to is missing");
-    };
+    }
 
     if (connection.getVirtualHost() != null) {
       builder.virtualHost(connection.getVirtualHost());
@@ -75,19 +73,18 @@ public class FlusswerkConfiguration {
           }
         });
 
-
     return builder.build();
   }
 
   /**
-   * @param messageBroker         The messageBroker to use.
-   * @param flowProvider          The flow to use (optional).
-   * @param flusswerkProperties   The external configuration from <code>application.yml</code>.
+   * @param messageBroker The messageBroker to use.
+   * @param flowProvider The flow to use (optional).
+   * @param flusswerkProperties The external configuration from <code>application.yml</code>.
    * @param processReportProvider A custom process report provider (optional).
-   * @param <I>                   The message's identifier type.
-   * @param <M>                   The used {@link Message} type
-   * @param <R>                   The type of the reader implementation
-   * @param <W>                   The type of the writer implementation
+   * @param <I> The message's identifier type.
+   * @param <M> The used {@link Message} type
+   * @param <R> The type of the reader implementation
+   * @param <W> The type of the writer implementation
    * @return The {@link Engine} used for this job.
    * @throws IOException If connection to RabbitMQ fails permanently.
    */

--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkProperties.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkProperties.java
@@ -20,23 +20,23 @@ public class FlusswerkProperties {
   static class Processing {
 
     @Min(0)
-    private int maxRetries;
+    private Integer maxRetries;
 
     @Min(1)
-    private int threads;
+    private Integer threads;
 
-    public Processing(@Min(0) int maxRetries, @Min(1) int threads) {
+    public Processing(@Min(0) Integer maxRetries, @Min(1) Integer threads) {
       this.maxRetries = maxRetries;
       this.threads = threads;
     }
 
     /** @return the maximum number of retries before a message ends up in the failed queue. */
-    public int getMaxRetries() {
+    public Integer getMaxRetries() {
       return maxRetries;
     }
 
     /** @return The number of concurrent processing threads in one job instance. */
-    public int getThreads() {
+    public Integer getThreads() {
       return threads;
     }
 

--- a/spring-boot-starter-flusswerk/src/test/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfigurationTest.java
+++ b/spring-boot-starter-flusswerk/src/test/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfigurationTest.java
@@ -1,0 +1,40 @@
+package de.digitalcollections.flusswerk.spring.boot.starter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class FlusswerkConfigurationTest {
+
+  @Test
+  public void isSetShouldDetectNull() {
+    assertThat(FlusswerkConfiguration.isSet(null)).isFalse();
+  }
+
+  @Test
+  public void isSetShouldDetectEmptyString() {
+    assertThat(FlusswerkConfiguration.isSet("")).isFalse();
+  }
+
+  @ParameterizedTest(name = "{index} value=\"{0}\"")
+  @ValueSource(strings = {" ", "\\n", "  \\t\\n "})
+  public void isSetShouldDetectWhitespace(String string) {
+    // String replace for JUnit output
+    String value = string.replace("\\n", "\n").replace("\\t", "\t");
+    assertThat(FlusswerkConfiguration.isSet(value)).isFalse();
+  }
+
+  @Test
+  public void isSetShouldDetectValue() {
+    assertThat(FlusswerkConfiguration.isSet("name")).isTrue();
+  }
+
+
+  @Test
+  public void isSetShouldAcceptNonStrings() {
+    assertThat(FlusswerkConfiguration.isSet(42)).isTrue();
+  }
+
+}


### PR DESCRIPTION
Almost all arguments are optional with sane defaults. The configuration
via application.yml should support the same behaviour and not produce
NullPointerExceptions.