### PR TITLE
Add a simple metrics callback for monitoring

### DIFF
--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/Flow.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/Flow.java
@@ -94,7 +94,7 @@ public class Flow<M extends Message, R, W> {
       }
       flowStatus.stop();
       if (monitor != null) {
-        monitor.accept(flowStatus);
+        monitor.accept(flowStatus); // record metrics only available from inside the framework
       }
     }
 

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
@@ -206,7 +206,8 @@ public class FlowBuilder<M extends Message, R, W> {
   }
 
   /**
-   * Sets a monitoring callback that is called after all processing and cleanup is finished.
+   * Sets a monitoring callback that is called after all processing and cleanup is finished. Metrics
+   * provided by flow status are provided by Flusswerk and would be inaccessible otherwise.
    *
    * @param consumer The consumer to be executed to record status.
    * @return This {@link FlowBuilder} instance for further configuration or creation of the {@link

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
@@ -238,6 +238,16 @@ public class FlowBuilder<M extends Message, R, W> {
     return new FlowBuilder<>();
   }
 
+  public static <M extends Message, R, W> FlowBuilder<M, R, W> with(
+      Class<M> messageClass, Class<R> transformerInput, Class<W> transformerOutput) {
+    return new FlowBuilder<>();
+  }
+
+  public static <M extends Message, T> FlowBuilder<M, T, T> with(
+      Class<M> messageClass, Class<T> dataClass) {
+    return new FlowBuilder<>();
+  }
+
   public static <M extends Message<?>, R, W> Flow<M, R, W> createFlow(
       Class<M> cls, Function<M, R> reader, Function<R, W> transformer, Consumer<W> writer) {
     return FlowBuilder.<M, R, W>receiving(cls)

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
@@ -30,6 +30,8 @@ public class FlowBuilder<M extends Message, R, W> {
 
   private boolean propagateFlowIds;
 
+  private Consumer<FlowStatus> monitor;
+
   public FlowBuilder() {
     this.propagateFlowIds = false;
   }
@@ -204,6 +206,19 @@ public class FlowBuilder<M extends Message, R, W> {
   }
 
   /**
+   * Sets a monitoring callback that is called after all processing and cleanup is finished.
+   *
+   * @param consumer The consumer to be executed to record status.
+   * @return This {@link FlowBuilder} instance for further configuration or creation of the {@link
+   *     Flow}.
+   */
+  public FlowBuilder<M, R, W> monitor(Consumer<FlowStatus> consumer) {
+    requireNonNull(consumer, "The runnable cannot be null");
+    this.monitor = consumer;
+    return this;
+  }
+
+  /**
    * Finally builds the flow.
    *
    * @return A new {@link Flow} as configured before.
@@ -215,7 +230,8 @@ public class FlowBuilder<M extends Message, R, W> {
         writerFactory,
         consumingWriterFactory,
         cleanup,
-        propagateFlowIds);
+        propagateFlowIds,
+        monitor);
   }
 
   public static <M extends Message, R, W> FlowBuilder<M, R, W> receiving(Class<M> clazz) {

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowStatus.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowStatus.java
@@ -1,0 +1,37 @@
+package de.digitalcollections.flusswerk.engine.flow;
+
+public class FlowStatus {
+
+  enum Status {
+    SUCCESS,
+    ERROR_RETRY,
+    ERROR_STOP
+  }
+
+  private long startTime;
+
+  private long endTime;
+
+  private Status status;
+
+  public FlowStatus() {
+    this.startTime = System.currentTimeMillis();
+    this.status = Status.SUCCESS;
+  }
+
+  public void stop() {
+    this.endTime = System.currentTimeMillis();
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+
+  void setStatus(Status status) {
+    this.status = status;
+  }
+
+  public long duration() {
+    return this.endTime - this.startTime;
+  }
+}

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowStatus.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowStatus.java
@@ -2,7 +2,7 @@ package de.digitalcollections.flusswerk.engine.flow;
 
 public class FlowStatus {
 
-  enum Status {
+  public enum Status {
     SUCCESS,
     ERROR_RETRY,
     ERROR_STOP

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowStatus.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowStatus.java
@@ -1,5 +1,12 @@
 package de.digitalcollections.flusswerk.engine.flow;
 
+import java.util.function.Consumer;
+
+/**
+ * Collect base metrics for a single flow - did the execution have errors and how long does it take?
+ *
+ * <p>Used for metrics handlers in {@link FlowBuilder#monitor(Consumer)}
+ */
 public class FlowStatus {
 
   public enum Status {

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/exceptions/ExceptionSupplierTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/exceptions/ExceptionSupplierTest.java
@@ -9,7 +9,7 @@ class ExceptionSupplierTest {
 
   @Test
   void shoudlSupplyExceptionWithOnlyMessage() {
-    var args = new String[]{};
+    var args = new String[] {};
     var supplier = new ExceptionSupplier<>(RetryProcessingException.class, "Hallo Welt", null);
     assertThat(supplier.get())
         .isInstanceOf(RetryProcessingException.class)
@@ -18,17 +18,17 @@ class ExceptionSupplierTest {
 
   @Test
   void shoudlSupplyStopProcessingExceptionWithOnlyMessage() {
-    var args = new String[]{};
+    var args = new String[] {};
     var supplier = new ExceptionSupplier<>(StopProcessingException.class, "Hallo Welt", null);
-    assertThat(supplier.get())
-        .isInstanceOf(StopProcessingException.class)
-        .hasMessage("Hallo Welt");
+    assertThat(supplier.get()).isInstanceOf(StopProcessingException.class).hasMessage("Hallo Welt");
   }
 
   @Test
   void shoudlSupplyExceptionWithMessageAndCause() {
-    var args = new String[]{};
-    var supplier = new ExceptionSupplier<>(RetryProcessingException.class, "Hallo Welt", null).causedBy(new RuntimeException("THE CAUSE"));
+    var args = new String[] {};
+    var supplier =
+        new ExceptionSupplier<>(RetryProcessingException.class, "Hallo Welt", null)
+            .causedBy(new RuntimeException("THE CAUSE"));
     assertThat(supplier.get())
         .isInstanceOf(RetryProcessingException.class)
         .hasMessage("Hallo Welt");
@@ -36,11 +36,11 @@ class ExceptionSupplierTest {
 
   @Test
   void shoudlSupplyStopProcessingExceptionWithMessageAndCause() {
-    var args = new String[]{};
-    var supplier = new ExceptionSupplier<>(StopProcessingException.class, "Hallo Welt", null).causedBy(new RuntimeException("THE CAUSE"));;
-    assertThat(supplier.get())
-        .isInstanceOf(StopProcessingException.class)
-        .hasMessage("Hallo Welt");
+    var args = new String[] {};
+    var supplier =
+        new ExceptionSupplier<>(StopProcessingException.class, "Hallo Welt", null)
+            .causedBy(new RuntimeException("THE CAUSE"));
+    ;
+    assertThat(supplier.get()).isInstanceOf(StopProcessingException.class).hasMessage("Hallo Welt");
   }
-
 }


### PR DESCRIPTION
To enable monitoring, each flow needs to provide execution information.
A callback can registered so that arbitrary monitoring code can be
integrated.