### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>de.digitalcollections.flusswerk</groupId>
     <artifactId>dc-flusswerk-parent</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/examples-plain/pom.xml
+++ b/examples-plain/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>de.digitalcollections.flusswerk</groupId>
     <artifactId>dc-flusswerk-parent</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/examples-spring-boot/pom.xml
+++ b/examples-spring-boot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dc-flusswerk-parent</artifactId>
     <groupId>de.digitalcollections.flusswerk</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dc-flusswerk-parent</artifactId>
     <groupId>de.digitalcollections.flusswerk</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>de.digitalcollections.flusswerk</groupId>
   <artifactId>dc-flusswerk-parent</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.0</version>
   <packaging>pom</packaging>
 
   <name>Flusswerk</name>

--- a/spring-boot-starter-flusswerk/pom.xml
+++ b/spring-boot-starter-flusswerk/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dc-flusswerk-parent</artifactId>
     <groupId>de.digitalcollections.flusswerk</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Version 3.10 introduces

  - Support for Spring Boot:
    - a Spring Boot Starter for autoconfiguration
    - configuration via application.yml
    - provide metrics via Spring Boot actuator and Promtheus

  - Improved exception handling:
    - new exception types that are easier to understand
      (StopProcessingException and RetryProcessingException)
    - new exception types now require error descriptions in any case
    - convenience API for error handling, esp. in combination with
      Java's Optional

  - Simplified custom messages:
    - new base class for ready to go custom message implementations
    - a new API to implement custom messages: Implementing
      FlusswerMessage is now all you need
    - Custom Jackson mixins are now optional

  - new API for collecting metrics
  - minor fixes and improvements

Version 3.1.0 prepares:

  - The control exception types of previous versions are deprecated now
    and will be removed in version 4.0.0