### PR TITLE
Fix metrics configuration

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>de.digitalcollections.flusswerk</groupId>
     <artifactId>dc-flusswerk-parent</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/examples-plain/pom.xml
+++ b/examples-plain/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>de.digitalcollections.flusswerk</groupId>
     <artifactId>dc-flusswerk-parent</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/examples-spring-boot/pom.xml
+++ b/examples-spring-boot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dc-flusswerk-parent</artifactId>
     <groupId>de.digitalcollections.flusswerk</groupId>
-    <version>3.1.0</version>
+    <version>3.1.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dc-flusswerk-parent</artifactId>
     <groupId>de.digitalcollections.flusswerk</groupId>
-    <version>3.1.0</version>
+    <version>3.1.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>de.digitalcollections.flusswerk</groupId>
   <artifactId>dc-flusswerk-parent</artifactId>
-  <version>3.1.0</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Flusswerk</name>

--- a/spring-boot-starter-flusswerk/pom.xml
+++ b/spring-boot-starter-flusswerk/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dc-flusswerk-parent</artifactId>
     <groupId>de.digitalcollections.flusswerk</groupId>
-    <version>3.1.0</version>
+    <version>3.1.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkProperties.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkProperties.java
@@ -181,6 +181,7 @@ public class FlusswerkProperties {
     this.processing = processing;
     this.connection = connection;
     this.routing = routing;
+    this.monitoring = monitoring;
   }
 
   public Processing getProcessing() {

--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/monitoring/MeterFactory.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/monitoring/MeterFactory.java
@@ -25,9 +25,9 @@ public class MeterFactory {
    */
   public MeterFactory(
       FlusswerkProperties flusswerkProperties,
-      @Value("spring.application.name") String app,
+      @Value("${spring.application.name}") String app,
       MeterRegistry registry) {
-    this.basename = flusswerkProperties.getConnection().getConnectTo();
+    this.basename = flusswerkProperties.getMonitoring().getPrefix();
     this.app = app;
     this.registry = registry;
   }

--- a/spring-boot-starter-flusswerk/src/test/java/de/digitalcollections/flusswerk/spring/boot/starter/monitoring/MeterFactoryTest.java
+++ b/spring-boot-starter-flusswerk/src/test/java/de/digitalcollections/flusswerk/spring/boot/starter/monitoring/MeterFactoryTest.java
@@ -28,5 +28,4 @@ class MeterFactoryTest {
     Search search = meterRegistry.find(monitoringPrefix + "." + monitoringMetric);
     assertThat(search.counter()).isEqualTo(counter);
   }
-
 }

--- a/spring-boot-starter-flusswerk/src/test/java/de/digitalcollections/flusswerk/spring/boot/starter/monitoring/MeterFactoryTest.java
+++ b/spring-boot-starter-flusswerk/src/test/java/de/digitalcollections/flusswerk/spring/boot/starter/monitoring/MeterFactoryTest.java
@@ -1,0 +1,32 @@
+package de.digitalcollections.flusswerk.spring.boot.starter.monitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import de.digitalcollections.flusswerk.spring.boot.starter.FlusswerkProperties;
+import de.digitalcollections.flusswerk.spring.boot.starter.FlusswerkProperties.Monitoring;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.search.Search;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+class MeterFactoryTest {
+
+  @Test
+  void shouldUseMonitoringPrefix() {
+    var monitoringPrefix = "testprefix";
+    var monitoringMetric = "testmetric";
+
+    FlusswerkProperties flusswerkProperties = mock(FlusswerkProperties.class);
+    when(flusswerkProperties.getMonitoring()).thenReturn(new Monitoring(monitoringPrefix));
+
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    MeterFactory meterFactory = new MeterFactory(flusswerkProperties, "testapp", meterRegistry);
+
+    Counter counter = meterFactory.counter(monitoringMetric);
+    Search search = meterRegistry.find(monitoringPrefix + "." + monitoringMetric);
+    assertThat(search.counter()).isEqualTo(counter);
+  }
+
+}


### PR DESCRIPTION
The existing had a bug in using the right prefix for metrics and app
name. This changeset fixes both.