### PR TITLE
Add powerful type API for FlowBuilder

### DIFF
--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
@@ -244,8 +244,54 @@ public class FlowBuilder<M extends Message, R, W> {
     return new FlowBuilder<>();
   }
 
+  /**
+   * Create a FlowBuilder for the specified types. The use of {@link Type} instances allows to
+   * declare types with specific generics (e.g. <code>Type<&lt;List&lt;String&gt;&gt;</code>).
+   * @param message The message type
+   * @param transformerInput The type for the transformer input (=reader output)
+   * @param transformerOutput The type for the transformer output (=writer input)
+   * @param <M> The message type
+   * @param <R> The type for the transformer input (=reader output).
+   * @param <W> The type for the transformer output (=writer input)
+   * @return a new {@link FlowBuilder} instance.
+   */
+  public static <M extends Message, R, W> FlowBuilder<M, R, W> with(
+      Type<M> message, Type<R> transformerInput, Type<W> transformerOutput) {
+    return new FlowBuilder<>();
+  }
+
+  /**
+   *  <p>Create a FlowBuilder for the specified types.</p>
+   *
+   *  <p>This is a convenience API for flows that use the same input datatype for transformer and
+   *  writer</p>
+   *
+   * @param messageClass The message class
+   * @param dataClass The data class
+   * @param <M> The message type
+   * @param <T> The data type
+   * @return a new {@link FlowBuilder} instance
+   */
   public static <M extends Message, T> FlowBuilder<M, T, T> with(
       Class<M> messageClass, Class<T> dataClass) {
+    return new FlowBuilder<>();
+  }
+
+  /**
+   *  <p>Create a FlowBuilder for the specified types. The use of {@link Type} instances allows to
+   *  declare types with specific generics (e.g. <code>Type<&lt;List&lt;String&gt;&gt;</code>).</p>
+   *
+   *  <p>This is a convenience API for flows that use the same input datatype for transformer and
+   *  writer</p>
+   *
+   * @param message The message type
+   * @param data The data type
+   * @param <M> The message type
+   * @param <T> The data type
+   * @return a new {@link FlowBuilder} instance
+   */
+  public static <M extends Message, T> FlowBuilder<M, T, T> with(
+      Type<M> message, Type<T> data) {
     return new FlowBuilder<>();
   }
 

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
@@ -246,7 +246,8 @@ public class FlowBuilder<M extends Message, R, W> {
 
   /**
    * Create a FlowBuilder for the specified types. The use of {@link Type} instances allows to
-   * declare types with specific generics (e.g. <code>Type<&lt;List&lt;String&gt;&gt;</code>).
+   * declare types with specific generics (e.g. <code>Type&lt;List&lt;String&gt;&gt;</code>).
+   *
    * @param message The message type
    * @param transformerInput The type for the transformer input (=reader output)
    * @param transformerOutput The type for the transformer output (=writer input)
@@ -261,10 +262,10 @@ public class FlowBuilder<M extends Message, R, W> {
   }
 
   /**
-   *  <p>Create a FlowBuilder for the specified types.</p>
+   * Create a FlowBuilder for the specified types.
    *
-   *  <p>This is a convenience API for flows that use the same input datatype for transformer and
-   *  writer</p>
+   * <p>This is a convenience API for flows that use the same input datatype for transformer and
+   * writer
    *
    * @param messageClass The message class
    * @param dataClass The data class
@@ -278,11 +279,11 @@ public class FlowBuilder<M extends Message, R, W> {
   }
 
   /**
-   *  <p>Create a FlowBuilder for the specified types. The use of {@link Type} instances allows to
-   *  declare types with specific generics (e.g. <code>Type<&lt;List&lt;String&gt;&gt;</code>).</p>
+   * Create a FlowBuilder for the specified types. The use of {@link Type} instances allows to
+   * declare types with specific generics (e.g. <code>Type&lt;List&lt;String&gt;&gt;</code>).
    *
-   *  <p>This is a convenience API for flows that use the same input datatype for transformer and
-   *  writer</p>
+   * <p>This is a convenience API for flows that use the same input datatype for transformer and
+   * writer
    *
    * @param message The message type
    * @param data The data type
@@ -290,8 +291,7 @@ public class FlowBuilder<M extends Message, R, W> {
    * @param <T> The data type
    * @return a new {@link FlowBuilder} instance
    */
-  public static <M extends Message, T> FlowBuilder<M, T, T> with(
-      Type<M> message, Type<T> data) {
+  public static <M extends Message, T> FlowBuilder<M, T, T> with(Type<M> message, Type<T> data) {
     return new FlowBuilder<>();
   }
 

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/Type.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/Type.java
@@ -1,0 +1,8 @@
+package de.digitalcollections.flusswerk.engine.flow;
+
+/**
+ * A type instance represents a generic type information for the fluent FlowBuilder interface.
+ *
+ * @param <T> The type to specify for the respective flow.
+ */
+public class Type<T> {}

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/EngineTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/EngineTest.java
@@ -42,7 +42,8 @@ class EngineTest {
     return flowWithTransformer(Function.identity());
   }
 
-  private Flow<DefaultMessage, String, String> flowWithTransformer(Function<String, String> transformer) {
+  private Flow<DefaultMessage, String, String> flowWithTransformer(
+      Function<String, String> transformer) {
     return new FlowBuilder<DefaultMessage, String, String>()
         .read(DefaultMessage::getId)
         .transform(transformer)
@@ -55,25 +56,30 @@ class EngineTest {
     final RuntimeException exception;
     try {
       exception = cls.getConstructor(String.class).newInstance(message);
-    } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+    } catch (InstantiationException
+        | IllegalAccessException
+        | InvocationTargetException
+        | NoSuchMethodException e) {
       throw new Error("Could not instantiate exception", e); // If test is broken give up
     }
-    Function<String, String> transformerWithException = s -> {
-      throw exception;
-    };
+    Function<String, String> transformerWithException =
+        s -> {
+          throw exception;
+        };
     return flowWithTransformer(transformerWithException);
   }
-
 
   @Test
   @DisplayName("should use the maximum number of workers")
   public void engineShouldUseMaxNumberOfWorkers() throws IOException, InterruptedException {
     when(messageBroker.receive()).thenReturn(new DefaultMessage("White Room"));
 
-    Engine engine = new Engine(
-        messageBroker,
-        flowWithTransformer(new ThreadBlockingTransformer<>()) // Force engine to use all worker threads
-    );
+    Engine engine =
+        new Engine(
+            messageBroker,
+            flowWithTransformer(
+                new ThreadBlockingTransformer<>()) // Force engine to use all worker threads
+            );
     ExecutorService executorService = Executors.newSingleThreadExecutor();
     executorService.submit(engine::start);
 
@@ -98,9 +104,10 @@ class EngineTest {
   @Test
   @DisplayName("should reject a message when processing fails")
   void processShouldRejectMessageOnFailure() throws IOException {
-    Function<String, String> transformerWithException = s -> {
-      throw new RuntimeException("Aaaaaaah!");
-    };
+    Function<String, String> transformerWithException =
+        s -> {
+          throw new RuntimeException("Aaaaaaah!");
+        };
 
     var flow = flowWithTransformer(transformerWithException);
 
@@ -161,6 +168,7 @@ class EngineTest {
 
     verify(messageBroker).fail(message);
   }
+
   @Test
   @DisplayName("should stop processing for good for StopProcessingException")
   void shoudlFailMessageForStopProcessingException() throws IOException {
@@ -176,7 +184,8 @@ class EngineTest {
   void testFunctionalReporter() throws IOException {
     final AtomicBoolean reportHasBeenCalled = new AtomicBoolean(false);
     ReportFunction reportFn = (r, msg, e) -> reportHasBeenCalled.set(true);
-    Engine engine = new Engine(messageBroker, flowThrowing(StopProcessingException.class), 4, reportFn);
+    Engine engine =
+        new Engine(messageBroker, flowThrowing(StopProcessingException.class), 4, reportFn);
     engine.process(new DefaultMessage());
     assertThat(reportHasBeenCalled).isTrue();
   }

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/ThreadBlockingTransformer.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/ThreadBlockingTransformer.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Transformer that blocks the current thread by trying to acquire a drained semaphor.
+ *
  * @param <T> The data type to operate on.
  */
 class ThreadBlockingTransformer<T> implements UnaryOperator<T> {


### PR DESCRIPTION
Java generics are limited as they are implemented using type erasure for
backwards compatibility. Therefore, specifying types using class
references does not work if the classes have generics. As this
information is used for typesafe builder pattern APIs, instances of a
generic Type-class can provide the missing information.