### PR TITLE
Add prototype for new FlowBuilder API

### DIFF
--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/ExperimentalFlowBuilder.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/ExperimentalFlowBuilder.java
@@ -1,0 +1,101 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import de.digitalcollections.flusswerk.engine.flow.Type;
+import de.digitalcollections.flusswerk.engine.model.Message;
+
+/**
+ * Experimental implementation of a new FlowBuilderApi. This might change in details in Flusswerk 4
+ * where it will become the regular implementation.
+ */
+public class ExperimentalFlowBuilder {
+
+  /**
+   * Create a builder for a new read/transform/write flow. Transform might be omitted later if types
+   * for reader output (<code>R</code>) and writer input (<code>W</code>) match.
+   *
+   * @param messageClass the message class
+   * @param readerOut the class of reader output/transformer input
+   * @param writerIn the class of transformer output/writer input
+   * @param <M> Generic type for the message class
+   * @param <R> Generic type for the reader output/transformer input
+   * @param <W> Generic type for the transformer output/writer input
+   * @return a new builder for a new flow
+   */
+  public static <M extends Message, R, W> SetReaderStep<M, R, W> flow(
+      Class<M> messageClass, Class<R> readerOut, Class<W> writerIn) {
+    return new SetReaderStep<>(new Model<>());
+  }
+
+  /**
+   * Create a builder for a new read/transform/write flow for the special case that the reader
+   * output type is used throughout the flow. Transform might be omitted later.
+   *
+   * @param messageClass the message class
+   * @param modelType the class of reader output/writer input
+   * @param <M> Generic type for the message class
+   * @param <T> Generic type for the reader output/writer input
+   * @return a new builder for a new flow
+   */
+  public static <M extends Message, T> SetReaderStep<M, T, T> flow(
+      Class<M> messageClass, Class<T> modelType) {
+    return new SetReaderStep<>(new Model<>());
+  }
+
+  /**
+   * Create a builder for a new read/transform/write flow. Transform might be omitted later if types
+   * for reader output (<code>R</code>) and writer input (<code>W</code>) match.
+   *
+   * @param messageClass the message class
+   * @param readerOut the type of reader output/transformer input
+   * @param writerIn the type of transformer output/writer input
+   * @param <M> Generic type for the message class
+   * @param <R> Generic type for the reader output/transformer input
+   * @param <W> Generic type for the transformer output/writer input
+   * @return a new builder for a new flow
+   */
+  public static <M extends Message, R, W> SetReaderStep<M, R, W> flow(
+      Type<M> messageClass, Type<R> readerOut, Type<W> writerIn) {
+    return new SetReaderStep<>(new Model<>());
+  }
+
+  /**
+   * Create a builder for a new read/transform/write flow for the special case that the reader
+   * output type is used throughout the flow. Transform might be omitted later.
+   *
+   * @param messageClass the message type
+   * @param modelType the class of reader output/writer input
+   * @param <M> Generic type for the message class
+   * @param <T> Generic type for the reader output/writer input
+   * @return a new builder for a new flow
+   */
+  public static <M extends Message, T> SetReaderStep<M, T, T> flow(
+      Type<M> messageClass, Type<T> modelType) {
+    return new SetReaderStep<>(new Model<>());
+  }
+
+  /**
+   * Create builder for a special flow that operates on the messages only and does not fit the usual
+   * read/transform/write pattern.
+   *
+   * @param messageClass The message class to operate on
+   * @param <M> The generic type for the message class to operate on
+   * @return a new builder for a new flow
+   */
+  public static <M extends Message> SetMessageProcessorStep<M> messageProcessor(
+      Class<M> messageClass) {
+    return new SetMessageProcessorStep<>(new Model<>());
+  }
+
+  /**
+   * Create builder for a special flow that operates on the messages only and does not fit the usual
+   * read/transform/write pattern.
+   *
+   * @param messageType The message type to operate on
+   * @param <M> The generic type for the message class to operate on
+   * @return a new builder for a new flow
+   */
+  public static <M extends Message> SetMessageProcessorStep<M> messageProcessor(
+      Type<M> messageType) {
+    return new SetMessageProcessorStep<>(new Model<>());
+  }
+}

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/Model.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/Model.java
@@ -10,7 +10,7 @@ class Model<M extends Message, R, W> {
   private Function<M, R> reader = null;
   private Function<R, W> transformer = null;
   private Function<W, Collection<Message>> writer = null;
-  private Consumer<FlowStatus> monitor = null;
+  private Consumer<FlowStatus> metrics = null;
   private Runnable cleanup = null;
   private boolean propagateFlowIds = false;
 
@@ -38,12 +38,12 @@ class Model<M extends Message, R, W> {
     this.writer = writer;
   }
 
-  public Consumer<FlowStatus> getMonitor() {
-    return monitor;
+  public Consumer<FlowStatus> getMetrics() {
+    return metrics;
   }
 
-  public void setMonitor(Consumer<FlowStatus> monitor) {
-    this.monitor = monitor;
+  public void setMetrics(Consumer<FlowStatus> monitor) {
+    this.metrics = monitor;
   }
 
   public Runnable getCleanup() {

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/Model.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/Model.java
@@ -1,0 +1,64 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import de.digitalcollections.flusswerk.engine.flow.FlowStatus;
+import de.digitalcollections.flusswerk.engine.model.Message;
+import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+class Model<M extends Message, R, W> {
+  private Function<M, R> reader = null;
+  private Function<R, W> transformer = null;
+  private Function<W, Collection<Message>> writer = null;
+  private Consumer<FlowStatus> monitor = null;
+  private Runnable cleanup = null;
+  private boolean propagateFlowIds = false;
+
+  public Function<M, R> getReader() {
+    return reader;
+  }
+
+  public void setReader(Function<M, R> reader) {
+    this.reader = reader;
+  }
+
+  public Function<R, W> getTransformer() {
+    return transformer;
+  }
+
+  public void setTransformer(Function<R, W> transformer) {
+    this.transformer = transformer;
+  }
+
+  public Function<W, Collection<Message>> getWriter() {
+    return writer;
+  }
+
+  public void setWriter(Function<W, Collection<Message>> writer) {
+    this.writer = writer;
+  }
+
+  public Consumer<FlowStatus> getMonitor() {
+    return monitor;
+  }
+
+  public void setMonitor(Consumer<FlowStatus> monitor) {
+    this.monitor = monitor;
+  }
+
+  public Runnable getCleanup() {
+    return cleanup;
+  }
+
+  public void setCleanup(Runnable cleanup) {
+    this.cleanup = cleanup;
+  }
+
+  public boolean isPropagateFlowIds() {
+    return propagateFlowIds;
+  }
+
+  public void setPropagateFlowIds(boolean propagateFlowIds) {
+    this.propagateFlowIds = propagateFlowIds;
+  }
+}

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetConfigurationStep.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetConfigurationStep.java
@@ -45,6 +45,19 @@ public class SetConfigurationStep<M extends Message, R, W> {
   }
 
   /**
+   * Sets if flow ids should be propagated from input to output messages. This will be replaced by a
+   * more automatic process in the next Flusswerk version and is here for compatibility reasons
+   * only.
+   *
+   * @param p true, if flow ids should be propagated
+   * @return the next step (setting configuration or build the flow)
+   */
+  public SetConfigurationStep<M, R, W> propagateFlowIds(boolean p) {
+    model.setPropagateFlowIds(p);
+    return this;
+  }
+
+  /**
    * Build the new flow.
    *
    * @return the new flow

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetConfigurationStep.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetConfigurationStep.java
@@ -1,0 +1,65 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import de.digitalcollections.flusswerk.engine.flow.Flow;
+import de.digitalcollections.flusswerk.engine.flow.FlowStatus;
+import de.digitalcollections.flusswerk.engine.model.Message;
+import java.util.function.Consumer;
+
+/**
+ * Set configuration for the new flow and build it.
+ *
+ * @param <M> The message class
+ * @param <R> Generic type for the reader output/transformer input
+ * @param <W> Generic type for the transformer output/writer input
+ */
+public class SetConfigurationStep<M extends Message, R, W> {
+
+  private Model<M, R, W> model;
+
+  SetConfigurationStep(Model<M, R, W> model) {
+    this.model = model;
+  }
+
+  /**
+   * Sets a process monitor that consumes a {@link FlowStatus} instance every time a message has
+   * been processed. builder step.
+   *
+   * @param m the process monitor
+   * @return the next step (setting configuration or build the flow)
+   */
+  public SetConfigurationStep<M, R, W> monitor(Consumer<FlowStatus> m) {
+    model.setMonitor(m);
+    return this;
+  }
+
+  /**
+   * Sets a cleanup task process monitor that consumes a {@link FlowStatus} instance every time a
+   * message has been processed. builder step.
+   *
+   * @param c the cleanup task
+   * @return the next step (setting configuration or build the flow)
+   */
+  public SetConfigurationStep<M, R, W> cleanup(Runnable c) {
+    model.setCleanup(c);
+    return this;
+  }
+
+  /**
+   * Build the new flow.
+   *
+   * @return the new flow
+   */
+  public Flow<M, R, W> build() {
+    // Suppliers are due to the Flow constructor interface. Suppliers are likely to be dropped in
+    // Flusswerk 4.
+    return new Flow<>(
+        () -> model.getReader(),
+        () -> model.getTransformer(),
+        () -> model.getWriter(),
+        null, // for cleaner implementation, adapting different writer types is completely done in
+        // the builder
+        model.getCleanup(),
+        model.isPropagateFlowIds(),
+        model.getMonitor());
+  }
+}

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetConfigurationStep.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetConfigurationStep.java
@@ -21,14 +21,14 @@ public class SetConfigurationStep<M extends Message, R, W> {
   }
 
   /**
-   * Sets a process monitor that consumes a {@link FlowStatus} instance every time a message has
-   * been processed. builder step.
+   * Sets a process metrics monitor that consumes a {@link FlowStatus} instance every time a message
+   * has been processed. builder step.
    *
-   * @param m the process monitor
+   * @param m the process metrics monitor
    * @return the next step (setting configuration or build the flow)
    */
-  public SetConfigurationStep<M, R, W> monitor(Consumer<FlowStatus> m) {
-    model.setMonitor(m);
+  public SetConfigurationStep<M, R, W> metrics(Consumer<FlowStatus> m) {
+    model.setMetrics(m);
     return this;
   }
 
@@ -60,6 +60,6 @@ public class SetConfigurationStep<M extends Message, R, W> {
         // the builder
         model.getCleanup(),
         model.isPropagateFlowIds(),
-        model.getMonitor());
+        model.getMetrics());
   }
 }

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetMessageProcessorStep.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetMessageProcessorStep.java
@@ -1,0 +1,34 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import de.digitalcollections.flusswerk.engine.model.Message;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Set a new message processor that takes a message and returns a {@link List} of messages.
+ *
+ * @param <M> The message class
+ */
+public class SetMessageProcessorStep<M extends Message> {
+
+  private Model<M, M, M> model;
+
+  SetMessageProcessorStep(Model<M, M, M> model) {
+    this.model = model;
+  }
+
+  /**
+   * Set a message processor that receives a message of type <code>M</code> and returns a {@link
+   * List} of {@link Message}, then moves you to the next builder step.
+   *
+   * @param p the message processor to set
+   * @return the next reader step
+   */
+  public SetConfigurationStep<M, M, M> process(Function<M, Collection<Message>> p) {
+    model.setReader(m -> m);
+    model.setTransformer(m -> m);
+    model.setWriter(p);
+    return new SetConfigurationStep<>(model);
+  }
+}

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetMessageProcessorStep.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetMessageProcessorStep.java
@@ -20,15 +20,30 @@ public class SetMessageProcessorStep<M extends Message> {
 
   /**
    * Set a message processor that receives a message of type <code>M</code> and returns a {@link
-   * List} of {@link Message}, then moves you to the next builder step.
+   * java.util.Collection} of {@link Message}, then moves you to the next builder step.
    *
    * @param p the message processor to set
    * @return the next reader step
    */
-  public SetConfigurationStep<M, M, M> process(Function<M, Collection<Message>> p) {
+  public SetConfigurationStep<M, M, M> expand(Function<M, Collection<Message>> p) {
     model.setReader(m -> m);
     model.setTransformer(m -> m);
     model.setWriter(p);
+    return new SetConfigurationStep<>(model);
+  }
+
+
+  /**
+   * Set a message processor that receives a message of type <code>M</code> and returns an arbitrary
+   * {@link Message}, then moves you to the next builder step.
+   *
+   * @param p the message processor to set
+   * @return the next reader step
+   */
+  public SetConfigurationStep<M, M, M> process(Function<M, Message> p) {
+    model.setReader(m -> m);
+    model.setTransformer(m -> m);
+    model.setWriter(List::of);
     return new SetConfigurationStep<>(model);
   }
 }

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetMessageProcessorStep.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetMessageProcessorStep.java
@@ -32,7 +32,6 @@ public class SetMessageProcessorStep<M extends Message> {
     return new SetConfigurationStep<>(model);
   }
 
-
   /**
    * Set a message processor that receives a message of type <code>M</code> and returns an arbitrary
    * {@link Message}, then moves you to the next builder step.
@@ -43,7 +42,7 @@ public class SetMessageProcessorStep<M extends Message> {
   public SetConfigurationStep<M, M, M> process(Function<M, Message> p) {
     model.setReader(m -> m);
     model.setTransformer(m -> m);
-    model.setWriter(List::of);
+    model.setWriter(p.andThen(List::of));
     return new SetConfigurationStep<>(model);
   }
 }

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetReaderStep.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetReaderStep.java
@@ -1,0 +1,32 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import de.digitalcollections.flusswerk.engine.model.Message;
+import java.util.function.Function;
+
+/**
+ * Set a new reader while building the new flow (typesafe).
+ *
+ * @param <M> The message class
+ * @param <R> Generic type for the reader output/transformer input
+ * @param <W> Generic type for the transformer output/writer input
+ */
+public class SetReaderStep<M extends Message, R, W> {
+
+  private Model<M, R, W> model;
+
+  SetReaderStep(Model<M, R, W> model) {
+    this.model = model;
+  }
+
+  /**
+   * Sets a reader that receives a message of type <code>M</code> and creates a model object of type
+   * <code>R</code>, then moves you to the next builder step.
+   *
+   * @param r the reader to set
+   * @return the next reader step
+   */
+  public SetTransformerStep<M, R, W> reader(Function<M, R> r) {
+    model.setReader(r);
+    return new SetTransformerStep<>(model);
+  }
+}

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetTransformerStep.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetTransformerStep.java
@@ -1,0 +1,42 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import de.digitalcollections.flusswerk.engine.model.Message;
+import java.util.function.Function;
+
+/**
+ * Set a new transformer while building the new flow (typesafe).
+ *
+ * @param <M> The message class
+ * @param <R> Generic type for the reader output/transformer input
+ * @param <W> Generic type for the transformer output/writer input
+ */
+public class SetTransformerStep<M extends Message, R, W> {
+
+  private Model<M, R, W> model;
+
+  public SetTransformerStep(Model<M, R, W> model) {
+    this.model = model;
+  }
+
+  /**
+   * Sets a transformer that receives data of type <code>R</code> and returns new data of type
+   * <code>R</code>, then moves you to the next builder step.
+   *
+   * @param t the transformer to set
+   * @return the next step (setting a writer)
+   */
+  public SetWriterStep<M, R, W> transformer(Function<R, W> t) {
+    model.setTransformer(t);
+    return new SetWriterStep<>(model);
+  }
+
+  /**
+   * Declares that the flow does not have a transformer and the output of the reader should go
+   * directly into the writer, then moves you to the next builder step (seting a writer).
+   *
+   * @return the next step (setting a writer)
+   */
+  public SetWriterStep<M, R, W> noTransformer() {
+    return new SetWriterStep<>(model);
+  }
+}

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetWriterStep.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/builder/SetWriterStep.java
@@ -1,0 +1,72 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import de.digitalcollections.flusswerk.engine.model.Message;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Set a new writer while building the new flow (typesafe).
+ *
+ * @param <M> The message class
+ * @param <R> Generic type for the reader output/transformer input
+ * @param <W> Generic type for the transformer output/writer input
+ */
+public class SetWriterStep<M extends Message, R, W> {
+
+  private Model<M, R, W> model;
+
+  public SetWriterStep(Model<M, R, W> model) {
+    this.model = model;
+  }
+
+  /**
+   * Sets a writer that receives data of type and stops processing, then moves you to the next
+   * builder step.
+   *
+   * @param w the writer to set
+   * @return the next step (setting configuration or build the flow)
+   */
+  public SetConfigurationStep<M, R, W> writerSendingNothing(Consumer<W> w) {
+    model.setWriter(
+        item -> {
+          w.accept(item);
+          return Collections.emptyList();
+        });
+    return new SetConfigurationStep<>(model);
+  }
+
+  /**
+   * Sets a writer that receives data of type and sends a new message, then moves you to the next
+   * builder step.
+   *
+   * @param w the writer to set
+   * @return the next step (setting configuration or build the flow)
+   */
+  public SetConfigurationStep<M, R, W> writerSendingMessage(Function<W, Message> w) {
+    model.setWriter(
+        item -> {
+          var result = w.apply(item);
+          if (result == null) {
+            return Collections.emptyList();
+          } else {
+            return List.of(result);
+          }
+        });
+    return new SetConfigurationStep<>(model);
+  }
+
+  /**
+   * Sets a writer that receives data of type and sends a {@link List} of new messages, then moves
+   * you to the next builder step.
+   *
+   * @param w the writer to set
+   * @return the next step (setting configuration or build the flow)
+   */
+  public SetConfigurationStep<M, R, W> writerSendingMessages(Function<W, Collection<Message>> w) {
+    model.setWriter(w);
+    return new SetConfigurationStep<>(model);
+  }
+}

--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/TraceableMessage.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/model/TraceableMessage.java
@@ -1,0 +1,14 @@
+package de.digitalcollections.flusswerk.engine.model;
+
+public abstract class TraceableMessage extends FlusswerkMessage {
+
+  private final String tracingId;
+
+  public TraceableMessage(String tracingId) {
+    this.tracingId = tracingId;
+  }
+
+  public String getTracingId() {
+    return tracingId;
+  }
+}

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/ExperimentalFlowBuilderTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/ExperimentalFlowBuilderTest.java
@@ -1,9 +1,9 @@
 package de.digitalcollections.flusswerk.engine.flow.builder;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import de.digitalcollections.flusswerk.engine.flow.Flow;
+import de.digitalcollections.flusswerk.engine.flow.Type;
 import de.digitalcollections.flusswerk.engine.model.DefaultMessage;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -13,7 +13,8 @@ import org.junit.jupiter.api.Test;
 class ExperimentalFlowBuilderTest {
 
   @Test
-  void shouldBuildAFlow() {
+  @DisplayName("should build a regular flow (using classes)")
+  void shouldBuildRegularFlowUsingClasses() {
     Flow<DefaultMessage, String, String> flow =
         ExperimentalFlowBuilder.flow(DefaultMessage.class, String.class, String.class)
             .reader(DefaultMessage::getId)
@@ -24,10 +25,54 @@ class ExperimentalFlowBuilderTest {
   }
 
   @Test
-  void shouldBuildAMessageProcessingFlow() {
+  @DisplayName("should build a regular flow (using types)")
+  void shouldBuildRegularFlowUsingTypes() {
+    Flow<DefaultMessage, String, String> flow =
+        ExperimentalFlowBuilder.flow(
+                new Type<DefaultMessage>() {}, new Type<String>() {}, new Type<String>() {})
+            .reader(DefaultMessage::getId)
+            .transformer(String::toUpperCase)
+            .writerSendingMessage(DefaultMessage::new)
+            .build();
+    assertThat(flow).isNotNull(); // Lame test, just a API demo for now
+  }
+
+  @Test
+  @DisplayName("should build a message processing flow sending a single message (using class)")
+  void shouldBuildMessageProcessingFlowReturningSingleMessage() {
     Flow<DefaultMessage, DefaultMessage, DefaultMessage> flow =
         ExperimentalFlowBuilder.messageProcessor(DefaultMessage.class)
-            .process(message -> List.of(message, message, message))
+            .process(message -> new DefaultMessage(message.getId()))
+            .build();
+    assertThat(flow).isNotNull(); // Lame test, just a API demo for now
+  }
+
+  @Test
+  @DisplayName("should build a message processing flow sending a single message (using types)")
+  void shouldBuildMessageProcessingFlowReturningSingleMessageUsingTypes() {
+    Flow<DefaultMessage, DefaultMessage, DefaultMessage> flow =
+        ExperimentalFlowBuilder.messageProcessor(new Type<DefaultMessage>() {})
+            .process(message -> new DefaultMessage(message.getId()))
+            .build();
+    assertThat(flow).isNotNull(); // Lame test, just a API demo for now
+  }
+
+  @Test
+  @DisplayName("should build a message processing flow sending a multiple messages (using class)")
+  void shouldBuildMessageProcessingFlowReturningManyMessages() {
+    Flow<DefaultMessage, DefaultMessage, DefaultMessage> flow =
+        ExperimentalFlowBuilder.messageProcessor(DefaultMessage.class)
+            .expand(message -> List.of(message, message, message))
+            .build();
+    assertThat(flow).isNotNull(); // Lame test, just a API demo for now
+  }
+
+  @Test
+  @DisplayName("should build a message processing flow sending a multiple messages (using types)")
+  void shouldBuildMessageProcessingFlowReturningManyMessagesUsingTypes() {
+    Flow<DefaultMessage, DefaultMessage, DefaultMessage> flow =
+        ExperimentalFlowBuilder.messageProcessor(new Type<DefaultMessage>() {})
+            .expand(message -> List.of(message, message, message))
             .build();
     assertThat(flow).isNotNull(); // Lame test, just a API demo for now
   }

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/ExperimentalFlowBuilderTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/ExperimentalFlowBuilderTest.java
@@ -1,0 +1,34 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.digitalcollections.flusswerk.engine.flow.Flow;
+import de.digitalcollections.flusswerk.engine.model.DefaultMessage;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("The ExperimentalFlowBuilder")
+class ExperimentalFlowBuilderTest {
+
+  @Test
+  void shouldBuildAFlow() {
+    Flow<DefaultMessage, String, String> flow =
+        ExperimentalFlowBuilder.flow(DefaultMessage.class, String.class, String.class)
+            .reader(DefaultMessage::getId)
+            .transformer(String::toUpperCase)
+            .writerSendingMessage(DefaultMessage::new)
+            .build();
+    assertThat(flow).isNotNull(); // Lame test, just a API demo for now
+  }
+
+  @Test
+  void shouldBuildAMessageProcessingFlow() {
+    Flow<DefaultMessage, DefaultMessage, DefaultMessage> flow =
+        ExperimentalFlowBuilder.messageProcessor(DefaultMessage.class)
+            .process(message -> List.of(message, message, message))
+            .build();
+    assertThat(flow).isNotNull(); // Lame test, just a API demo for now
+  }
+}

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/InvocationProbe.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/InvocationProbe.java
@@ -1,0 +1,31 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import java.util.function.Consumer;
+import org.assertj.core.api.Condition;
+
+class InvocationProbe<T> implements Consumer<T>, Runnable {
+
+  private int invocations = 0;
+
+  @Override
+  public void accept(T s) {
+    invocations++;
+  }
+
+  @Override
+  public void run() {
+    invocations++;
+  }
+
+  public boolean hasBeenInvoked() {
+    return invocations > 0;
+  }
+
+  public int getInvocations() {
+    return invocations;
+  }
+
+  public static Condition<? super InvocationProbe<?>> beenInvoked() {
+    return new Condition<>(InvocationProbe::hasBeenInvoked, "at least one invocation");
+  }
+}

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/SetConfigurationStepTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/SetConfigurationStepTest.java
@@ -1,0 +1,50 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import static de.digitalcollections.flusswerk.engine.flow.builder.InvocationProbe.beenInvoked;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.digitalcollections.flusswerk.engine.flow.FlowStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("The SetConfigurationStep")
+public class SetConfigurationStepTest {
+
+  private Model<TestMessage, String, String> model;
+  private SetConfigurationStep<TestMessage, String, String> step;
+
+  @BeforeEach
+  void setUp() {
+    model = new Model<>();
+    step = new SetConfigurationStep<>(model);
+  }
+
+  @DisplayName("should set the cleanup task")
+  @Test
+  void shouldSetCleanupTask2() {
+    var cleanupTask = new InvocationProbe<>();
+    step.cleanup(cleanupTask);
+    model.getCleanup().run();
+    assertThat(cleanupTask).has(beenInvoked());
+  }
+
+  @DisplayName("should set the metrics task")
+  @Test
+  void shouldSetMetricsTask() {
+    var metricsTask = new InvocationProbe<FlowStatus>();
+    step.metrics(metricsTask);
+    model.getMetrics().accept(null);
+    assertThat(metricsTask).has(beenInvoked());
+  }
+
+  @DisplayName("should propagate flow ids")
+  @ValueSource(booleans = {true, false})
+  @ParameterizedTest
+  void shouldSetMetricsTask(boolean value) {
+    step.propagateFlowIds(value);
+    assertThat(model.isPropagateFlowIds()).isEqualTo(value);
+  }
+}

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/SetMessageProcessorStepTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/SetMessageProcessorStepTest.java
@@ -1,0 +1,54 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("The SetMessageProcessorStep")
+class SetMessageProcessorStepTest {
+
+  private Model<TestMessage, TestMessage, TestMessage> model;
+  private SetMessageProcessorStep<TestMessage> step;
+
+  @BeforeEach
+  void setUp() {
+    model = new Model<>();
+    step = new SetMessageProcessorStep<>(model);
+  }
+
+  @Test
+  @DisplayName("should add a process to expand one message to many")
+  void shouldAddProcessToConvertOneMessageToMany() {
+
+    step.expand(message -> message.values().map(TestMessage::new).collect(Collectors.toList()));
+
+    TestMessage[] expected = {new TestMessage("a"), new TestMessage("b"), new TestMessage("c")};
+
+    var message = new TestMessage("1", allIdsOf(expected));
+    var actual =
+        model.getReader().andThen(model.getTransformer()).andThen(model.getWriter()).apply(message);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  @DisplayName("should add a process to convert one message to another")
+  void shouldAddProcessToConvertOneMessageToAnother() {
+    step.process(m -> new TestMessage(m.getValues().get(0)));
+
+    var expected = new TestMessage("a");
+    var message = new TestMessage("1", expected.getId());
+    var actual =
+        model.getReader().andThen(model.getTransformer()).andThen(model.getWriter()).apply(message);
+
+    assertThat(actual).containsExactly(expected);
+  }
+
+  String[] allIdsOf(TestMessage... messages) {
+    return Stream.of(messages).map(TestMessage::getId).toArray(String[]::new);
+  }
+}

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/SetReaderStepTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/SetReaderStepTest.java
@@ -1,0 +1,29 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.digitalcollections.flusswerk.engine.model.FlusswerkMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("The SetReaderStep")
+class SetReaderStepTest {
+
+  @BeforeEach
+  void setUp() {}
+
+  @DisplayName("should set a reader")
+  @Test
+  void shouldSetReader() {
+    Model<TestMessage, String, String> model = new Model<>();
+    SetReaderStep<TestMessage, String, String> step = new SetReaderStep<>(model);
+
+    step.reader(FlusswerkMessage::getId);
+
+    var expected = "test";
+    var actual = model.getReader().apply(new TestMessage(expected));
+    assertThat(actual).isEqualTo(expected);
+  }
+}

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/SetTransformerStepTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/SetTransformerStepTest.java
@@ -1,0 +1,34 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SetTransformerStepTest {
+
+  private Model<TestMessage, String, String> model;
+  private SetTransformerStep<TestMessage, String, String> step;
+
+  @BeforeEach
+  void setUp() {
+    model = new Model<>();
+    step = new SetTransformerStep<>(model);
+  }
+
+  @Test
+  void transformer() {
+    step.transformer(String::toUpperCase);
+
+    var expected = "TEST";
+    var actual = model.getTransformer().apply("test");
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void noTransformer() {
+    step.noTransformer();
+    assertThat(model.getTransformer()).isNull();
+  }
+}

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/SetWriterStepTest.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/SetWriterStepTest.java
@@ -1,0 +1,53 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import static de.digitalcollections.flusswerk.engine.flow.builder.InvocationProbe.beenInvoked;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SetWriterStepTest {
+
+  private Model<TestMessage, String, String> model;
+  private SetWriterStep<TestMessage, String, String> step;
+
+  @BeforeEach
+  void setUp() {
+    model = new Model<>();
+    step = new SetWriterStep<>(model);
+  }
+
+  @Test
+  void writerSendingNothing() {
+    var consumingWriter = new InvocationProbe<String>();
+    step.writerSendingNothing(consumingWriter);
+
+    var actual = model.getWriter().apply("test");
+    assertThat(consumingWriter).has(beenInvoked());
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void writerSendingMessage() {
+    step.writerSendingMessage(TestMessage::new);
+
+    var expected = new TestMessage("test");
+    var actual = model.getWriter().apply(expected.getId());
+    assertThat(actual).containsExactly(expected);
+  }
+
+  @Test
+  void writerSendingMessages_2() {
+    TestMessage[] expected = {new TestMessage("1"), new TestMessage("2"), new TestMessage("3")};
+    step.writerSendingMessages(anything -> List.of(expected));
+
+    var actual = model.getWriter().apply("123");
+    assertThat(actual).containsExactly(expected);
+  }
+
+  TestMessage[] messagesForIds(String... id) {
+    return Stream.of(id).map(TestMessage::new).toArray(TestMessage[]::new);
+  }
+}

--- a/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/TestMessage.java
+++ b/engine/src/test/java/de/digitalcollections/flusswerk/engine/flow/builder/TestMessage.java
@@ -1,0 +1,55 @@
+package de.digitalcollections.flusswerk.engine.flow.builder;
+
+import static java.util.Objects.requireNonNull;
+
+import de.digitalcollections.flusswerk.engine.model.FlusswerkMessage;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class TestMessage extends FlusswerkMessage<String> {
+
+  private List<String> values;
+
+  public TestMessage(String id) {
+    super(requireNonNull(id));
+    this.values = Collections.emptyList();
+  }
+
+  public TestMessage(String id, String... values) {
+    super(requireNonNull(id));
+    this.values = Arrays.asList(values);
+  }
+
+  public List<String> getValues() {
+    return values;
+  }
+
+  public Stream<String> values() {
+    return values.stream();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o instanceof TestMessage) {
+      TestMessage other = (TestMessage) o;
+      return id.equals(other.id) && values.equals(other.values);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, values);
+  }
+
+  @Override
+  public String toString() {
+    return "TestMessage{" + "values=" + values + ", id=" + id + '}';
+  }
+}


### PR DESCRIPTION
The new FlowBuilder API exposes only the necessary options for IDE
autocomplete and introduces a simplified process for message conversion
workflows.