### PR TITLE
Add metrics collection to Spring Boot starter

### DIFF
--- a/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
+++ b/engine/src/main/java/de/digitalcollections/flusswerk/engine/flow/FlowBuilder.java
@@ -212,8 +212,25 @@ public class FlowBuilder<M extends Message, R, W> {
    * @param consumer The consumer to be executed to record status.
    * @return This {@link FlowBuilder} instance for further configuration or creation of the {@link
    *     Flow}.
+   * @deprecated use <code>measure</code> instead
    */
+  @Deprecated
   public FlowBuilder<M, R, W> monitor(Consumer<FlowStatus> consumer) {
+    requireNonNull(consumer, "The runnable cannot be null");
+    this.monitor = consumer;
+    return this;
+  }
+
+  /**
+   * Sets a callback that is called after all processing and cleanup is finished to collect data on
+   * flow execution. Metrics provided by flow status are provided by Flusswerk and would be
+   * inaccessible otherwise.
+   *
+   * @param consumer The consumer to be executed to record status.
+   * @return This {@link FlowBuilder} instance for further configuration or creation of the {@link
+   *     Flow}.
+   */
+  public FlowBuilder<M, R, W> measure(Consumer<FlowStatus> consumer) {
     requireNonNull(consumer, "The runnable cannot be null");
     this.monitor = consumer;
     return this;

--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfiguration.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/FlusswerkConfiguration.java
@@ -6,8 +6,11 @@ import de.digitalcollections.flusswerk.engine.messagebroker.MessageBroker;
 import de.digitalcollections.flusswerk.engine.messagebroker.MessageBrokerBuilder;
 import de.digitalcollections.flusswerk.engine.model.Message;
 import de.digitalcollections.flusswerk.engine.reporting.ProcessReport;
+import de.digitalcollections.flusswerk.spring.boot.starter.monitoring.MeterFactory;
+import de.digitalcollections.flusswerk.spring.boot.starter.monitoring.Metrics;
 import java.io.IOException;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -116,6 +119,12 @@ public class FlusswerkConfiguration {
 
     ProcessReport processReport = processReportProvider.getIfAvailable();
     return new Engine(messageBroker, flow, threads, processReport);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public Metrics metrics(MeterFactory meterFactory) {
+    return new Metrics(meterFactory);
   }
 
   public static boolean isSet(Object value) {

--- a/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/monitoring/Metrics.java
+++ b/spring-boot-starter-flusswerk/src/main/java/de/digitalcollections/flusswerk/spring/boot/starter/monitoring/Metrics.java
@@ -1,0 +1,31 @@
+package de.digitalcollections.flusswerk.spring.boot.starter.monitoring;
+
+import de.digitalcollections.flusswerk.engine.flow.FlowStatus;
+import de.digitalcollections.flusswerk.engine.flow.FlowStatus.Status;
+import io.micrometer.core.instrument.Counter;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/** Collect metrics on flow execution. */
+public class Metrics implements Consumer<FlowStatus> {
+
+  private final Map<Status, Counter> executionTime;
+  private final Map<Status, Counter> processedItems;
+
+  public Metrics(MeterFactory meterFactory) {
+    this.executionTime = new EnumMap<>(Status.class);
+    this.processedItems = new EnumMap<>(Status.class);
+
+    for (Status status : Status.values()) {
+      processedItems.put(status, meterFactory.counter("processed.items", status));
+      executionTime.put(status, meterFactory.counter("execution.time", status));
+    }
+  }
+
+  public void accept(FlowStatus flowStatus) {
+    var status = flowStatus.getStatus();
+    processedItems.get(status).increment();
+    executionTime.get(status).increment(flowStatus.duration());
+  }
+}


### PR DESCRIPTION
The new Metrics bean supports the common collection tasks for total
processed messages and total execution time, each counted seperately for
successful processing, processing with errors and retry, processing with
errors that lead to abort processing. This bean is only created if the
user does not provide a Metrics bean first.