### PR TITLE
Automatically propagate tracing ids if present

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
@@ -34,8 +34,6 @@ public class Flow<M extends Message, R, W> {
 
   private final Runnable cleanup;
 
-  private final boolean propagateFlowIds;
-
   private final Consumer<FlowStatus> monitor;
 
   public Flow(
@@ -44,20 +42,18 @@ public class Flow<M extends Message, R, W> {
       Supplier<Function<W, Collection<Message>>> writerFactory,
       Supplier<Consumer<W>> consumingWriterFactory,
       Runnable cleanup,
-      boolean propagateFlowIds,
       Consumer<FlowStatus> monitor) {
     this.readerFactory = readerFactory;
     this.transformerFactory = transformerFactory;
     this.writerFactory = writerFactory;
     this.consumingWriterFactory = consumingWriterFactory;
     this.cleanup = cleanup;
-    this.propagateFlowIds = propagateFlowIds;
     this.monitor = monitor;
   }
 
   public Collection<Message> process(M message) {
     FlowStatus flowStatus = new FlowStatus();
-    Job<M, R, W> job = new Job<>(message, propagateFlowIds);
+    Job<M, R, W> job = new Job<>(message);
 
     final Collection<Message> result;
 

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
@@ -30,8 +30,6 @@ public class Flow<M extends Message, R, W> {
 
   private final Supplier<Function<W, Collection<Message>>> writerFactory;
 
-  private final Supplier<Consumer<W>> consumingWriterFactory;
-
   private final Runnable cleanup;
 
   private final Consumer<FlowStatus> monitor;
@@ -40,13 +38,11 @@ public class Flow<M extends Message, R, W> {
       Supplier<Function<M, R>> readerFactory,
       Supplier<Function<R, W>> transformerFactory,
       Supplier<Function<W, Collection<Message>>> writerFactory,
-      Supplier<Consumer<W>> consumingWriterFactory,
       Runnable cleanup,
       Consumer<FlowStatus> monitor) {
     this.readerFactory = readerFactory;
     this.transformerFactory = transformerFactory;
     this.writerFactory = writerFactory;
-    this.consumingWriterFactory = consumingWriterFactory;
     this.cleanup = cleanup;
     this.monitor = monitor;
   }
@@ -67,10 +63,6 @@ public class Flow<M extends Message, R, W> {
       if (writerFactory != null) {
         job.write(writerFactory.get());
       }
-      if (consumingWriterFactory != null) {
-        job.write(consumingWriterFactory.get());
-      }
-
     } catch (RuntimeException e) {
       if (e instanceof StopProcessingException) {
         flowStatus.setStatus(Status.ERROR_STOP);

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/ConfigurationStep.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/ConfigurationStep.java
@@ -56,8 +56,6 @@ public class ConfigurationStep<M extends Message, R, W> {
         model::getReader,
         model::getTransformer,
         model::getWriter,
-        null, // for cleaner implementation, adapting different writer types is completely done in
-        // the builder
         model.getCleanup(),
         model.getMetrics());
   }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/ConfigurationStep.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/ConfigurationStep.java
@@ -45,19 +45,6 @@ public class ConfigurationStep<M extends Message, R, W> {
   }
 
   /**
-   * Sets if flow ids should be propagated from input to output messages. This will be replaced by a
-   * more automatic process in the next Flusswerk version and is here for compatibility reasons
-   * only.
-   *
-   * @param p true, if flow ids should be propagated
-   * @return the next step (setting configuration or build the flow)
-   */
-  public ConfigurationStep<M, R, W> propagateFlowIds(boolean p) {
-    model.setPropagateFlowIds(p);
-    return this;
-  }
-
-  /**
    * Build the new flow.
    *
    * @return the new flow
@@ -66,13 +53,12 @@ public class ConfigurationStep<M extends Message, R, W> {
     // Suppliers are due to the Flow constructor interface. Suppliers are likely to be dropped in
     // Flusswerk 4.
     return new Flow<>(
-        () -> model.getReader(),
-        () -> model.getTransformer(),
-        () -> model.getWriter(),
+        model::getReader,
+        model::getTransformer,
+        model::getWriter,
         null, // for cleaner implementation, adapting different writer types is completely done in
         // the builder
         model.getCleanup(),
-        model.isPropagateFlowIds(),
         model.getMetrics());
   }
 }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/Model.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/Model.java
@@ -12,7 +12,6 @@ class Model<M extends Message, R, W> {
   private Function<W, Collection<Message>> writer = null;
   private Consumer<FlowStatus> metrics = null;
   private Runnable cleanup = null;
-  private boolean propagateFlowIds = false;
 
   public Function<M, R> getReader() {
     return reader;
@@ -54,11 +53,4 @@ class Model<M extends Message, R, W> {
     this.cleanup = cleanup;
   }
 
-  public boolean isPropagateFlowIds() {
-    return propagateFlowIds;
-  }
-
-  public void setPropagateFlowIds(boolean propagateFlowIds) {
-    this.propagateFlowIds = propagateFlowIds;
-  }
 }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Job.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Job.java
@@ -2,7 +2,6 @@ package com.github.dbmdz.flusswerk.framework.model;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class Job<M extends Message, R, W> {

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Job.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Job.java
@@ -15,17 +15,10 @@ public class Job<M extends Message, R, W> {
 
   private Collection<Message> result;
 
-  private boolean propagateFlowIds;
-
   public Job(M message) {
     this.message = message;
     this.dataRead = null;
     this.dataTransformed = null;
-  }
-
-  public Job(M message, boolean propagateFlowIds) {
-    this(message);
-    this.propagateFlowIds = propagateFlowIds;
   }
 
   public void read(Function<M, R> reader) {
@@ -48,10 +41,8 @@ public class Job<M extends Message, R, W> {
     if (result == null) {
       return Collections.emptyList();
     }
-    if (propagateFlowIds) {
-      for (Message newMessage : result) {
-        newMessage.setTracingId(message.getTracingId());
-      }
+    for (Message newMessage : result) {
+      newMessage.setTracingId(message.getTracingId());
     }
     return result;
   }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Job.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Job.java
@@ -42,6 +42,9 @@ public class Job<M extends Message, R, W> {
       return Collections.emptyList();
     }
     for (Message newMessage : result) {
+      if (newMessage == null || newMessage.getTracingId() != null) {
+        continue; // Do not update the tracing id if the user set one by hand
+      }
       newMessage.setTracingId(message.getTracingId());
     }
     return result;

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Job.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Job.java
@@ -33,10 +33,6 @@ public class Job<M extends Message, R, W> {
     result = writer.apply(dataTransformed);
   }
 
-  public void write(Consumer<W> writer) {
-    writer.accept(dataTransformed);
-  }
-
   public Collection<Message> getResult() {
     if (result == null) {
       return Collections.emptyList();

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/flow/builder/ConfigurationStepTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/flow/builder/ConfigurationStepTest.java
@@ -40,11 +40,4 @@ public class ConfigurationStepTest {
     assertThat(metricsTask).has(beenInvoked());
   }
 
-  @DisplayName("should propagate flow ids")
-  @ValueSource(booleans = {true, false})
-  @ParameterizedTest
-  void shouldSetMetricsTask(boolean value) {
-    step.propagateFlowIds(value);
-    assertThat(model.isPropagateFlowIds()).isEqualTo(value);
-  }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/model/JobTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/model/JobTest.java
@@ -82,7 +82,7 @@ class JobTest {
   @DisplayName("Should propagate flow ids")
   void propagateTracingIds() {
     Message incomingMessage = new Message("12345");
-    Job<Message, String, String> job = new Job<>(incomingMessage, true);
+    Job<Message, String, String> job = new Job<>(incomingMessage);
     job.read(m -> "");
     job.transform(Function.identity());
     job.write((Function<String, Collection<Message>>) s -> List.of(new Message()));

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/model/JobTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/model/JobTest.java
@@ -42,10 +42,6 @@ class JobTest {
     }
   }
 
-  private Supplier<RuntimeException> exception(String message) {
-    return () -> new RuntimeException(message);
-  }
-
   @Test
   @DisplayName("should call the reader")
   void read() {
@@ -80,8 +76,7 @@ class JobTest {
     Job<TestMessage, String, String> job = new Job<>(message);
     job.read(TestMessage::getId);
     job.transform(String::toUpperCase);
-    job.write(
-        (Function<String, Collection<Message>>) id -> Collections.singleton(new TestMessage(id)));
+    job.write(id -> Collections.singleton(new TestMessage(id)));
 
     var actual = (TestMessage) unbox(job.getResult());
     assertThat(actual.getId()).isEqualTo(message.getId().toUpperCase());


### PR DESCRIPTION
In Flusswerk 3 tracing had to be explicitly enabled. Now the framework recognizes if a tracing id is present in the incoming messages and propagates to all new messages.

Closes #148.