### PR TITLE
Remove broken connection test

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/messagebroker/MessageBroker.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/messagebroker/MessageBroker.java
@@ -265,8 +265,4 @@ public class MessageBroker {
     }
     return result;
   }
-
-  public boolean isConnectionOk() {
-    return rabbitClient.isChannelAvailable() && rabbitClient.isConnectionOk();
-  }
 }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/messagebroker/RabbitClient.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/messagebroker/RabbitClient.java
@@ -162,10 +162,6 @@ class RabbitClient {
     return channel.messageCount(queue);
   }
 
-  public boolean isConnectionOk() {
-    return connection.isOk();
-  }
-
   public boolean isChannelAvailable() {
     return channel.isOpen();
   }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/messagebroker/RabbitConnection.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/messagebroker/RabbitConnection.java
@@ -66,10 +66,4 @@ class RabbitConnection {
       }
     }
   }
-
-  public boolean isOk() {
-    // FIXME should it be "return channel.getConnection().isOpen()"? If not, comment!
-    channel.getConnection().isOpen();
-    return true;
-  }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/messagebroker/MessageBrokerTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/messagebroker/MessageBrokerTest.java
@@ -135,39 +135,6 @@ class MessageBrokerTest {
   }
 
   @Test
-  @DisplayName("isConnectionOk should be true if channel and connection are ok")
-  void isConnectionOkShouldBeTrueIfChannelAndConnectionAreOk() {
-    when(rabbitClient.isChannelAvailable()).thenReturn(true);
-    when(rabbitClient.isConnectionOk()).thenReturn(true);
-    assertThat(messageBroker.isConnectionOk()).isTrue();
-  }
-
-  @Test
-  @DisplayName("isConnectionOk should be false if channel is not available")
-  void isConnectionOkShouldBeTrueIfChannelIsNotAvailable() {
-    when(rabbitClient.isChannelAvailable()).thenReturn(false);
-    when(rabbitClient.isConnectionOk()).thenReturn(true);
-    assertThat(messageBroker.isConnectionOk()).isFalse();
-  }
-
-  @Test
-  @DisplayName("isConnectionOk should be false if connection is not ok")
-  void isConnectionOkShouldBeTrueIfConnectionIsNotOk() {
-    when(rabbitClient.isChannelAvailable()).thenReturn(true);
-    when(rabbitClient.isConnectionOk()).thenReturn(false);
-    assertThat(messageBroker.isConnectionOk()).isFalse();
-  }
-
-  @Test
-  @DisplayName(
-      "isConnectionOk should be false if channel is not available and connection is not ok")
-  void isConnectionOkShouldBeTrueIfChannelIsNotAvailableAndConnectionIsNotOk() {
-    when(rabbitClient.isChannelAvailable()).thenReturn(false);
-    when(rabbitClient.isConnectionOk()).thenReturn(false);
-    assertThat(messageBroker.isConnectionOk()).isFalse();
-  }
-
-  @Test
   @DisplayName("invalidMessage should be ACKed and shifted into fqiled queue")
   void handleInvalidMessage() throws IOException, InvalidMessageException {
     String invalidMessageBody = "invalid";

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/messagebroker/RabbitClientTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/messagebroker/RabbitClientTest.java
@@ -121,15 +121,6 @@ class RabbitClientTest {
   }
 
   @Test
-  @DisplayName("isConnectionOk should return if connection is ok")
-  void isConnectionOk() {
-    when(connection.isOk()).thenReturn(true, false);
-    RabbitClient rabbitClient = new RabbitClient(config, connection);
-    assertThat(rabbitClient.isConnectionOk()).isTrue();
-    assertThat(rabbitClient.isConnectionOk()).isFalse();
-  }
-
-  @Test
   @DisplayName("isChannelAvailable should return if channel is available")
   void isChannelAvailable() {
     when(channel.isOpen()).thenReturn(true, false);


### PR DESCRIPTION
The test API for working connections to RabbitMQ seems to been broken for a long time and therefore unused except for some unit tests that tested around the bug - removing for now completely.