### PR TITLE
Fix error handling when sending messages fails

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
@@ -8,7 +8,6 @@ import com.github.dbmdz.flusswerk.framework.reporting.DefaultProcessReport;
 import com.github.dbmdz.flusswerk.framework.reporting.ProcessReport;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
@@ -173,7 +173,7 @@ public class Engine {
       }
     } catch (IOException fatalException) {
       var body = receivedMessage.getEnvelope().getBody();
-      LOGGER.error("Could not reject message" + body, fatalExecption);
+      LOGGER.error("Could not reject message" + body, fatalException);
     }
   }
 
@@ -181,9 +181,9 @@ public class Engine {
     try {
       processReport.reportFail(message, e);
       messageBroker.fail(message);
-    } catch (IOException fatalExecption) {
+    } catch (IOException fatalException) {
       var body = message.getEnvelope().getBody();
-      LOGGER.error("Could not fail message" + body, fatalExecption);
+      LOGGER.error("Could not fail message" + body, fatalException);
     }
   }
 

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
@@ -141,7 +141,7 @@ public class Engine {
 
   @SuppressWarnings("unchecked")
   void process(Message message) {
-    Collection<? extends Message> messagesToSend = Collections.emptyList();
+    Collection<? extends Message> messagesToSend;
     try {
       messagesToSend = flow.process(message);
     } catch (StopProcessingException e) {

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
@@ -171,7 +171,7 @@ public class Engine {
       } else {
         processReport.reportFailAfterMaxRetries(receivedMessage, e);
       }
-    } catch (IOException fatalExecption) {
+    } catch (IOException fatalException) {
       var body = receivedMessage.getEnvelope().getBody();
       LOGGER.error("Could not reject message" + body, fatalExecption);
     }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
@@ -71,7 +71,4 @@ public class Flow<M extends Message, R, W> {
     return result;
   }
 
-  public boolean hasMessagesToSend() {
-    return writer != null;
-  }
 }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/messagebroker/MessageBroker.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/messagebroker/MessageBroker.java
@@ -51,6 +51,16 @@ public class MessageBroker {
   }
 
   /**
+   * Sends messages to the default output queue as JSON document.
+   *
+   * @param messages the message to send.
+   * @throws IOException if sending the message fails.
+   */
+  public void send(Collection<? extends Message> messages) throws IOException {
+    send(routingConfig.getWriteTo(), messages);
+  }
+
+  /**
    * Sends a message to a certain queue as JSON document.
    *
    * @param routingKey the routing key for the queue to send the message to (usually the queue
@@ -71,7 +81,7 @@ public class MessageBroker {
    * @param messages the messages to send.
    * @throws IOException if sending a message fails.
    */
-  public void send(String routingKey, Collection<Message> messages) throws IOException {
+  public void send(String routingKey, Collection<? extends Message> messages) throws IOException {
     for (Message message : messages) {
       send(routingKey, message);
     }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Message.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Message.java
@@ -38,4 +38,9 @@ public class Message {
   public String getTracingId() {
     return tracingId;
   }
+
+  @Override
+  public String toString() {
+    return String.format("Message{hashcode=%s, tracingId=%s", hashCode(), tracingId);
+  }
 }


### PR DESCRIPTION
When sending outgoing messages fails processing should stop as retrying
might cause situations that are very hard to debug (e.g. messages send
multiple times).

Fixes #149.