### PR TITLE
Refactor dependency management

### DIFF
--- a/examples-spring-boot/pom.xml
+++ b/examples-spring-boot/pom.xml
@@ -16,7 +16,6 @@
     <dependency>
       <groupId>com.github.dbmdz.flusswerk</groupId>
       <artifactId>framework</artifactId>
-      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -28,17 +27,5 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
   </dependencies>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
 </project>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -14,12 +14,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>net.logstash.logback</groupId>
-      <artifactId>logstash-logback-encoder</artifactId>
-      <version>${version.logstash}</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
@@ -34,7 +28,6 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>${version.micrometer}</version>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>
@@ -43,6 +36,11 @@
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>net.logstash.logback</groupId>
+      <artifactId>logstash-logback-encoder</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
@@ -79,7 +77,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <version>${version.spring-boot}</version>
     </dependency>
   </dependencies>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -24,12 +24,10 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>${version.micrometer}</version>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
-      <version>${version.micrometer}</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
@@ -43,12 +41,10 @@
     <dependency>
       <groupId>net.logstash.logback</groupId>
       <artifactId>logstash-logback-encoder</artifactId>
-      <version>${version.logstash}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <version>${version.spring-boot}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -58,7 +54,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-      <version>${version.spring-boot}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -132,14 +132,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-        </plugin>
-        <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${version.maven-jacoco-plugin}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.dbmdz.flusswerk</groupId>
   <artifactId>flusswerk</artifactId>
-  <version>${version.flusswerk}</version>
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Flusswerk</name>
@@ -75,6 +75,8 @@
     <!-- Plugin versions -->
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
     <version.maven-jacoco-plugin>0.8.5</version.maven-jacoco-plugin>
+    <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
+    <version.wagon-maven-plugin>2.0.0</version.wagon-maven-plugin>
   </properties>
 
   <dependencyManagement>
@@ -133,6 +135,11 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>wagon-maven-plugin</artifactId>
+          <version>${version.wagon-maven-plugin}</version>
+        </plugin>
+        <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${version.maven-jacoco-plugin}</version>
@@ -175,6 +182,7 @@
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>${version.nexus-staging-maven-plugin}</version>
           <extensions>true</extensions>
           <configuration>
             <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,18 +63,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Dependency versions -->
     <version.amqp-client>5.6.0</version.amqp-client>
-    <version.assertj>3.16.1</version.assertj>
-    <version.jackson>2.11.1</version.jackson>
-    <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
-    <version.junit>5.6.2</version.junit>
-    <version.logback>1.2.3</version.logback>
-    <version.logstash>6.4</version.logstash>
+    <version.logstash-encoder>6.4</version.logstash-encoder>
     <version.micrometer>1.5.1</version.micrometer>
-    <version.mockito>3.3.3</version.mockito>
     <version.redisson>3.13.1</version.redisson>
-    <version.slf4j>1.7.30</version.slf4j>
     <version.spring-boot>2.3.1.RELEASE</version.spring-boot>
-    <version.validation-api>2.0.1.Final</version.validation-api>
     <!-- Plugin versions -->
     <version.maven-checkstyle-plugin>3.1.0</version.maven-checkstyle-plugin>
     <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
@@ -89,26 +81,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${version.logback}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${version.jackson}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${version.jackson}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>${version.jackson}</version>
-      </dependency>
-      <dependency>
         <groupId>com.rabbitmq</groupId>
         <artifactId>amqp-client</artifactId>
         <version>${version.amqp-client}</version>
@@ -119,38 +91,9 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-core</artifactId>
-        <version>${version.assertj}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>javax.annotation</groupId>
-        <artifactId>javax.annotation-api</artifactId>
-        <version>${version.javax.annotation-api}</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>${version.validation-api}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>${version.junit}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${version.junit}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${version.mockito}</version>
-        <scope>test</scope>
+        <groupId>net.logstash.logback</groupId>
+        <artifactId>logstash-logback-encoder</artifactId>
+        <version>${version.logstash-encoder}</version>
       </dependency>
       <dependency>
         <groupId>org.redisson</groupId>
@@ -158,19 +101,11 @@
         <version>${version.redisson}</version>
       </dependency>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${version.slf4j}</version>
-      </dependency>
-      <dependency>
         <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter</artifactId>
+        <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-configuration-processor</artifactId>
-        <version>${version.spring-boot}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,12 @@
 
   <name>Flusswerk</name>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.3.1.RELEASE</version>
+  </parent>
+
   <description>
     Tooling for AMQP/RabbitMQ based workflow management.
   </description>
@@ -64,18 +70,10 @@
     <!-- Dependency versions -->
     <version.amqp-client>5.6.0</version.amqp-client>
     <version.logstash-encoder>6.4</version.logstash-encoder>
-    <version.micrometer>1.5.1</version.micrometer>
     <version.redisson>3.13.1</version.redisson>
-    <version.spring-boot>2.3.1.RELEASE</version.spring-boot>
     <!-- Plugin versions -->
-    <version.maven-checkstyle-plugin>3.1.0</version.maven-checkstyle-plugin>
-    <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
     <version.maven-jacoco-plugin>0.8.5</version.maven-jacoco-plugin>
-    <version.maven-javadoc-plugin>3.2.0</version.maven-javadoc-plugin>
-    <version.maven-surefire-plugin>3.0.0-M5</version.maven-surefire-plugin>
-    <version.maven-source-plugin>3.2.1</version.maven-source-plugin>
-    <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
   </properties>
 
   <dependencyManagement>
@@ -99,13 +97,6 @@
         <groupId>org.redisson</groupId>
         <artifactId>redisson</artifactId>
         <version>${version.redisson}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -143,12 +134,10 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${version.maven-compiler-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${version.maven-surefire-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
@@ -158,7 +147,6 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>cobertura-maven-plugin</artifactId>
-          <version>2.7</version>
           <configuration>
             <formats>
               <format>html</format>
@@ -170,7 +158,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>${version.maven-source-plugin}</version>
           <executions>
             <execution>
               <id>attach-sources</id>
@@ -183,7 +170,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>${version.maven-javadoc-plugin}</version>
           <executions>
             <execution>
               <id>attach-javadocs</id>
@@ -196,7 +182,6 @@
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>${version.nexus-staging-maven-plugin}</version>
           <extensions>true</extensions>
           <configuration>
             <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.dbmdz.flusswerk</groupId>
   <artifactId>flusswerk</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>${version.flusswerk}</version>
   <packaging>pom</packaging>
 
   <name>Flusswerk</name>
@@ -70,6 +70,7 @@
     <!-- Dependency versions -->
     <version.amqp-client>5.6.0</version.amqp-client>
     <version.logstash-encoder>6.4</version.logstash-encoder>
+    <version.flusswerk>4.0.0-SNAPSHOT</version.flusswerk>
     <version.redisson>3.13.1</version.redisson>
     <!-- Plugin versions -->
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
@@ -86,7 +87,7 @@
       <dependency>
         <groupId>com.github.dbmdz.flusswerk</groupId>
         <artifactId>framework</artifactId>
-        <version>${project.version}</version>
+        <version>${version.flusswerk}</version>
       </dependency>
       <dependency>
         <groupId>net.logstash.logback</groupId>


### PR DESCRIPTION
Flusswerk strongly builds upon Spring Boot. Therefore, dependency versions should be managed by Spring Boot where possible. Also, all other dependency versions are now only managed in the Maven parent pom.