### PR TITLE
Rename property for better IDE autocomplete

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/FlusswerkProperties.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/FlusswerkProperties.java
@@ -14,7 +14,7 @@ public class FlusswerkProperties {
 
   @NestedConfigurationProperty private final ProcessingProperties processing;
 
-  @NestedConfigurationProperty private final RabbitMQProperties rabbitMQ;
+  @NestedConfigurationProperty private final RabbitMQProperties rabbitmq;
 
   @NestedConfigurationProperty private final RoutingProperties routing;
 
@@ -25,12 +25,12 @@ public class FlusswerkProperties {
   @ConstructorBinding
   public FlusswerkProperties(
       ProcessingProperties processing,
-      RabbitMQProperties rabbitMQ,
+      RabbitMQProperties rabbitmq,
       RoutingProperties routing,
       MonitoringProperties monitoring,
       RedisProperties redis) {
     this.processing = requireNonNullElseGet(processing, ProcessingProperties::defaults);
-    this.rabbitMQ = requireNonNullElseGet(rabbitMQ, RabbitMQProperties::defaults);
+    this.rabbitmq = requireNonNullElseGet(rabbitmq, RabbitMQProperties::defaults);
     this.routing = requireNonNullElseGet(routing, RoutingProperties::defaults);
     this.monitoring = requireNonNullElseGet(monitoring, MonitoringProperties::defaults);
     this.redis = redis; // might actually be null, then centralized locking will be disabled
@@ -41,7 +41,7 @@ public class FlusswerkProperties {
   }
 
   public RabbitMQProperties getRabbitMQ() {
-    return rabbitMQ;
+    return rabbitmq;
   }
 
   public RoutingProperties getRouting() {
@@ -61,7 +61,7 @@ public class FlusswerkProperties {
     return StringRepresentation.of(FlusswerkProperties.class)
         .property("processing", processing.toString())
         .property("routing", routing.toString())
-        .property("connection", rabbitMQ.toString())
+        .property("connection", rabbitmq.toString())
         .property("monitoring", monitoring.toString())
         .toString();
   }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/MessageBroker.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/MessageBroker.java
@@ -40,7 +40,6 @@ public class MessageBroker {
    *
    * @param message the message to send.
    * @throws IOException if sending the message fails.
-   *
    * @deprecated Use {@link Topic#send(Message)} instead
    */
   @Deprecated
@@ -57,7 +56,6 @@ public class MessageBroker {
    *
    * @param messages the message to send.
    * @throws IOException if sending the message fails.
-   *
    * @deprecated Use {@link Topic#send(Message)} instead
    */
   @Deprecated
@@ -249,9 +247,9 @@ public class MessageBroker {
 
   /**
    * Returns the number of messages in known queues
+   *
    * @return the number of messages in known queues
    * @throws IOException if communication with RabbitMQ fails
-   *
    * @deprecated Use {@link Queue#messageCount()} instead.
    */
   @Deprecated


### PR DESCRIPTION
The Property name `rabbitMQ` shows up in autocomplete for `application.yml` as `rabbit-m-q`, so it is renamed to `rabbitmq`.