### PR TITLE
Add consuming message processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Maven:
 
 ```xml
 <dependency>
-  <groupId>com.github.dbmdz</groupId>
+  <groupId>com.github.dbmdz.flusswerk</groupId>
   <artifactId>framework</artifactId>
   <version>4.0.0</version>
 </dependency>

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/MessageProcessorStep.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/MessageProcessorStep.java
@@ -56,10 +56,13 @@ public class MessageProcessorStep<M extends Message> {
    * @param p the message processor to set
    * @return the next reader step
    */
-  public ConfigurationStep<M, M, M> consume(Consumer<M> p) {
+  public ConfigurationStep<M, M, M> consume(Consumer<M> consumer) {
     model.setReader(m -> m);
     model.setTransformer(m -> m);
-    model.setWriter(m -> emptyList());
+    model.setWriter(m -> {
+      consumer.accept(m);
+      return emptyList();
+    });
     return new ConfigurationStep<>(model);
   }
 }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/MessageProcessorStep.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/MessageProcessorStep.java
@@ -1,8 +1,11 @@
 package com.github.dbmdz.flusswerk.framework.flow.builder;
 
+import static java.util.Collections.emptyList;
+
 import com.github.dbmdz.flusswerk.framework.model.Message;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -43,6 +46,20 @@ public class MessageProcessorStep<M extends Message> {
     model.setReader(m -> m);
     model.setTransformer(m -> m);
     model.setWriter(p.andThen(List::of));
+    return new ConfigurationStep<>(model);
+  }
+
+  /**
+   * Set a message processor that receives a message of type <code>M</code> and does not return any
+   * {@link Message} for Flusswerk to send.
+   *
+   * @param p the message processor to set
+   * @return the next reader step
+   */
+  public ConfigurationStep<M, M, M> consume(Consumer<M> p) {
+    model.setReader(m -> m);
+    model.setTransformer(m -> m);
+    model.setWriter(m -> emptyList());
     return new ConfigurationStep<>(model);
   }
 }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/MessageProcessorStep.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/MessageProcessorStep.java
@@ -53,16 +53,17 @@ public class MessageProcessorStep<M extends Message> {
    * Set a message processor that receives a message of type <code>M</code> and does not return any
    * {@link Message} for Flusswerk to send.
    *
-   * @param p the message processor to set
+   * @param consumer the message processor to set
    * @return the next reader step
    */
   public ConfigurationStep<M, M, M> consume(Consumer<M> consumer) {
     model.setReader(m -> m);
     model.setTransformer(m -> m);
-    model.setWriter(m -> {
-      consumer.accept(m);
-      return emptyList();
-    });
+    model.setWriter(
+        m -> {
+          consumer.accept(m);
+          return emptyList();
+        });
     return new ConfigurationStep<>(model);
   }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/flow/builder/MessageProcessorStepTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/flow/builder/MessageProcessorStepTest.java
@@ -1,11 +1,12 @@
 package com.github.dbmdz.flusswerk.framework.flow.builder;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.github.dbmdz.flusswerk.framework.TestMessage;
 import com.github.dbmdz.flusswerk.framework.model.Message;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,7 @@ class MessageProcessorStepTest {
     var message = new TestMessage("1", allIdsOf(expected));
     var actual = evaluateFlow(message);
 
-    Assertions.assertThat(actual).containsExactly(expected);
+    assertThat(actual).containsExactly(expected);
   }
 
   @Test
@@ -45,18 +46,20 @@ class MessageProcessorStepTest {
     var message = new TestMessage("1", expected.getId());
     var actual = evaluateFlow(message);
 
-    Assertions.assertThat(actual).containsExactly(expected);
+    assertThat(actual).containsExactly(expected);
   }
 
   @Test
   @DisplayName("should consume message")
   void shouldConsumeMessage() {
-    step.consume(message -> {});
+    var probe = new InvocationProbe<TestMessage>();
+    step.consume(probe);
 
     var message = new TestMessage("1");
     var actual = evaluateFlow(message);
 
-    Assertions.assertThat(actual).isEmpty();
+    assertThat(actual).isEmpty();
+    assertThat(probe.hasBeenInvoked()).isTrue();
   }
 
   String[] allIdsOf(TestMessage... messages) {

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/flow/builder/MessageProcessorStepTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/flow/builder/MessageProcessorStepTest.java
@@ -1,6 +1,8 @@
 package com.github.dbmdz.flusswerk.framework.flow.builder;
 
 import com.github.dbmdz.flusswerk.framework.TestMessage;
+import com.github.dbmdz.flusswerk.framework.model.Message;
+import java.util.Collection;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
@@ -29,8 +31,7 @@ class MessageProcessorStepTest {
     TestMessage[] expected = {new TestMessage("a"), new TestMessage("b"), new TestMessage("c")};
 
     var message = new TestMessage("1", allIdsOf(expected));
-    var actual =
-        model.getReader().andThen(model.getTransformer()).andThen(model.getWriter()).apply(message);
+    var actual = evaluateFlow(message);
 
     Assertions.assertThat(actual).containsExactly(expected);
   }
@@ -42,13 +43,31 @@ class MessageProcessorStepTest {
 
     var expected = new TestMessage("a");
     var message = new TestMessage("1", expected.getId());
-    var actual =
-        model.getReader().andThen(model.getTransformer()).andThen(model.getWriter()).apply(message);
+    var actual = evaluateFlow(message);
 
     Assertions.assertThat(actual).containsExactly(expected);
   }
 
+  @Test
+  @DisplayName("should consume message")
+  void shouldConsumeMessage() {
+    step.consume(message -> {});
+
+    var message = new TestMessage("1");
+    var actual = evaluateFlow(message);
+
+    Assertions.assertThat(actual).isEmpty();
+  }
+
   String[] allIdsOf(TestMessage... messages) {
     return Stream.of(messages).map(TestMessage::getId).toArray(String[]::new);
+  }
+
+  private Collection<Message> evaluateFlow(TestMessage message) {
+    return model
+        .getReader()
+        .andThen(model.getTransformer())
+        .andThen(model.getWriter())
+        .apply(message);
   }
 }


### PR DESCRIPTION
Sometimes a workflow job should only consume incoming messages, but does
not want the Flusswerk framework to handle any messages to send.