### PR TITLE
Simplify api

### DIFF
--- a/examples-spring-boot/src/main/java/com/github/dbmdz/flusswerk/spring/boot/example/config/FlusswerkConfig.java
+++ b/examples-spring-boot/src/main/java/com/github/dbmdz/flusswerk/spring/boot/example/config/FlusswerkConfig.java
@@ -1,6 +1,7 @@
 package com.github.dbmdz.flusswerk.spring.boot.example.config;
 
 import com.github.dbmdz.flusswerk.framework.flow.Flow;
+import com.github.dbmdz.flusswerk.framework.flow.FlowSpec;
 import com.github.dbmdz.flusswerk.framework.flow.builder.FlowBuilder;
 import com.github.dbmdz.flusswerk.framework.locking.NoOpLockManager;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
@@ -21,15 +22,14 @@ public class FlusswerkConfig {
   }
 
   @Bean
-  public Flow<Greeting, String, String> flow(BaseMetrics metrics) {
-    var flowSpec =
+  public FlowSpec flow(BaseMetrics metrics) {
+    return
         FlowBuilder.flow(Greeting.class, String.class, String.class)
             .reader(Greeting::getText)
             .transformer(new ComposePerfectGreeting())
             .writerSendingNothing(System.out::println)
             .metrics(metrics)
             .build();
-    return new Flow<>(flowSpec, new NoOpLockManager());
   }
 
   @Bean

--- a/examples-spring-boot/src/main/java/com/github/dbmdz/flusswerk/spring/boot/example/config/FlusswerkConfig.java
+++ b/examples-spring-boot/src/main/java/com/github/dbmdz/flusswerk/spring/boot/example/config/FlusswerkConfig.java
@@ -21,13 +21,12 @@ public class FlusswerkConfig {
 
   @Bean
   public FlowSpec flow(BaseMetrics metrics) {
-    return
-        FlowBuilder.flow(Greeting.class, String.class, String.class)
-            .reader(Greeting::getText)
-            .transformer(new ComposePerfectGreeting())
-            .writerSendingNothing(System.out::println)
-            .metrics(metrics)
-            .build();
+    return FlowBuilder.flow(Greeting.class, String.class, String.class)
+        .reader(Greeting::getText)
+        .transformer(new ComposePerfectGreeting())
+        .writerSendingNothing(System.out::println)
+        .metrics(metrics)
+        .build();
   }
 
   @Bean

--- a/examples-spring-boot/src/main/java/com/github/dbmdz/flusswerk/spring/boot/example/config/FlusswerkConfig.java
+++ b/examples-spring-boot/src/main/java/com/github/dbmdz/flusswerk/spring/boot/example/config/FlusswerkConfig.java
@@ -1,9 +1,7 @@
 package com.github.dbmdz.flusswerk.spring.boot.example.config;
 
-import com.github.dbmdz.flusswerk.framework.flow.Flow;
 import com.github.dbmdz.flusswerk.framework.flow.FlowSpec;
 import com.github.dbmdz.flusswerk.framework.flow.builder.FlowBuilder;
-import com.github.dbmdz.flusswerk.framework.locking.NoOpLockManager;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.monitoring.BaseMetrics;
 import com.github.dbmdz.flusswerk.framework.reporting.ProcessReport;

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -39,7 +39,7 @@ public class FlusswerkConfiguration {
 
   @Bean
   public <M extends Message, R, W> Flow<M, R, W> flow(
-      ObjectProvider<FlowSpec<M, R, W>> flowSpec, LockManager lockManager) {
+      ObjectProvider<FlowSpec> flowSpec, LockManager lockManager) {
     var spec = flowSpec.getIfAvailable();
     if (spec == null) {
       throw new RuntimeException("Missing flow definition. Please create a FlowSpec bean.");

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -50,6 +50,7 @@ public class FlusswerkConfiguration {
    * @param flow The flow to use (optional).
    * @param flusswerkProperties The external configuration from <code>application.yml</code>.
    * @param processReportProvider A custom process report provider (optional).
+   * @param flowMetrics The metrics collector.
    * @return The {@link Engine} used for this job.
    */
   @Bean

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -9,7 +9,6 @@ import com.github.dbmdz.flusswerk.framework.locking.LockManager;
 import com.github.dbmdz.flusswerk.framework.locking.NoOpLockManager;
 import com.github.dbmdz.flusswerk.framework.locking.RedisLockManager;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
-import com.github.dbmdz.flusswerk.framework.model.Message;
 import com.github.dbmdz.flusswerk.framework.monitoring.BaseMetrics;
 import com.github.dbmdz.flusswerk.framework.monitoring.FlowMetrics;
 import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
@@ -38,13 +37,13 @@ import org.springframework.context.annotation.Import;
 public class FlusswerkConfiguration {
 
   @Bean
-  public <M extends Message, R, W> Flow<M, R, W> flow(
+  public Flow flow(
       ObjectProvider<FlowSpec> flowSpec, LockManager lockManager) {
     var spec = flowSpec.getIfAvailable();
     if (spec == null) {
       throw new RuntimeException("Missing flow definition. Please create a FlowSpec bean.");
     }
-    return new Flow<>(spec, lockManager);
+    return new Flow(spec, lockManager);
   }
 
   /**
@@ -52,16 +51,13 @@ public class FlusswerkConfiguration {
    * @param flow The flow to use (optional).
    * @param flusswerkProperties The external configuration from <code>application.yml</code>.
    * @param processReportProvider A custom process report provider (optional).
-   * @param <M> The used {@link Message} type
-   * @param <R> The type of the reader implementation
-   * @param <W> The type of the writer implementation
    * @return The {@link Engine} used for this job.
    */
   @Bean
-  public <M extends Message, R, W> Engine engine(
+  public Engine engine(
       @Value("spring.application.name") String name,
       MessageBroker messageBroker,
-      Flow<M, R, W> flow,
+      Flow flow,
       FlusswerkProperties flusswerkProperties,
       ObjectProvider<ProcessReport> processReportProvider,
       Set<FlowMetrics> flowMetrics) {

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -37,8 +37,7 @@ import org.springframework.context.annotation.Import;
 public class FlusswerkConfiguration {
 
   @Bean
-  public Flow flow(
-      ObjectProvider<FlowSpec> flowSpec, LockManager lockManager) {
+  public Flow flow(ObjectProvider<FlowSpec> flowSpec, LockManager lockManager) {
     var spec = flowSpec.getIfAvailable();
     if (spec == null) {
       throw new RuntimeException("Missing flow definition. Please create a FlowSpec bean.");

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/StringRepresentation.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/StringRepresentation.java
@@ -21,7 +21,7 @@ class StringRepresentation {
   }
 
   /**
-   * Add a property as key-value-pair with proper intendation.
+   * Add a property as key-value-pair with proper indentation.
    *
    * @param name The properties name.
    * @param value The properties value.

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
@@ -24,8 +24,6 @@ public class Engine {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Engine.class);
 
-  private static final int DEFAULT_CONCURRENT_WORKERS = 5;
-
   private final int concurrentWorkers;
 
   private final MessageBroker messageBroker;
@@ -118,7 +116,6 @@ public class Engine {
     engineStarted.unlock(); // Engine successfully stopped, could now be started again
   }
 
-  @SuppressWarnings("unchecked")
   void process(Message message) {
     Collection<? extends Message> messagesToSend;
     try {

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
@@ -16,7 +16,6 @@ import java.util.function.Function;
  * Recipe for the data processing. Every message will be processed by the readerFactory, then the
  * transformerFactory and finally the writerFactory. The transformerFactory can be omitted if <code>
  * R</code> and <code>W</code> are the same.
- *
  */
 public class Flow {
 

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
@@ -30,7 +30,7 @@ public class Flow<M extends Message, R, W> {
   private final Set<FlowMetrics> flowMetrics;
   private final LockManager lockManager;
 
-  public Flow(FlowSpec<M, R, W> flowSpec, LockManager lockManager) {
+  public Flow(FlowSpec flowSpec, LockManager lockManager) {
     this.reader = requireNonNull(flowSpec.getReader());
     this.transformer = requireNonNull(flowSpec.getTransformer());
     this.writer = requireNonNull(flowSpec.getWriter());

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
@@ -17,15 +17,12 @@ import java.util.function.Function;
  * transformerFactory and finally the writerFactory. The transformerFactory can be omitted if <code>
  * R</code> and <code>W</code> are the same.
  *
- * @param <M> The data type of the message.
- * @param <R> The data type produced by the reader. Input data type of the transformer.
- * @param <W> The data type consumed by the writer. Output data type of the transformer.
  */
-public class Flow<M extends Message, R, W> {
+public class Flow {
 
-  private final Function<M, R> reader;
-  private final Function<R, W> transformer;
-  private final Function<W, Collection<Message>> writer;
+  private final Function<Message, Object> reader;
+  private final Function<Object, Object> transformer;
+  private final Function<Object, Collection<Message>> writer;
   private final Runnable cleanup;
   private final Set<FlowMetrics> flowMetrics;
   private final LockManager lockManager;
@@ -43,7 +40,7 @@ public class Flow<M extends Message, R, W> {
     this.flowMetrics.addAll(flowMetrics);
   }
 
-  public Collection<Message> process(M message) {
+  public Collection<Message> process(Message message) {
     FlowInfo info = new FlowInfo();
     Collection<Message> result;
 

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/FlowSpec.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/FlowSpec.java
@@ -3,25 +3,25 @@ package com.github.dbmdz.flusswerk.framework.flow;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
+import com.github.dbmdz.flusswerk.framework.model.Message;
+import java.util.Collection;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class FlowSpec {
 
-  private final Function reader;
-
-  private final Function transformer;
-
-  private final Function writer;
+  private final Function<Message, Object> reader;
+  private final Function<Object, Object> transformer;
+  private final Function<Object, Collection<Message>> writer;
 
   private final Runnable cleanup;
 
   private final Consumer<FlowInfo> monitor;
 
   public FlowSpec(
-      Function reader,
-      Function transformer,
-      Function writer,
+      Function<Message, Object> reader,
+      Function<Object, Object> transformer,
+      Function<Object, Collection<Message>> writer,
       Runnable cleanup,
       Consumer<FlowInfo> monitor) {
     this.reader = requireNonNull(reader);
@@ -31,15 +31,15 @@ public class FlowSpec {
     this.monitor = requireNonNullElse(monitor, metrics -> {});
   }
 
-  public Function getReader() {
+  public Function<Message, Object> getReader() {
     return reader;
   }
 
-  public Function getTransformer() {
+  public Function<Object, Object> getTransformer() {
     return transformer;
   }
 
-  public Function getWriter() {
+  public Function<Object, Collection<Message>> getWriter() {
     return writer;
   }
 

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/FlowSpec.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/FlowSpec.java
@@ -3,27 +3,25 @@ package com.github.dbmdz.flusswerk.framework.flow;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
-import com.github.dbmdz.flusswerk.framework.model.Message;
-import java.util.Collection;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class FlowSpec<M, R, W> {
+public class FlowSpec {
 
-  private final Function<M, R> reader;
+  private final Function reader;
 
-  private final Function<R, W> transformer;
+  private final Function transformer;
 
-  private final Function<W, Collection<Message>> writer;
+  private final Function writer;
 
   private final Runnable cleanup;
 
   private final Consumer<FlowInfo> monitor;
 
   public FlowSpec(
-      Function<M, R> reader,
-      Function<R, W> transformer,
-      Function<W, Collection<Message>> writer,
+      Function reader,
+      Function transformer,
+      Function writer,
       Runnable cleanup,
       Consumer<FlowInfo> monitor) {
     this.reader = requireNonNull(reader);
@@ -33,15 +31,15 @@ public class FlowSpec<M, R, W> {
     this.monitor = requireNonNullElse(monitor, metrics -> {});
   }
 
-  public Function<M, R> getReader() {
+  public Function getReader() {
     return reader;
   }
 
-  public Function<R, W> getTransformer() {
+  public Function getTransformer() {
     return transformer;
   }
 
-  public Function<W, Collection<Message>> getWriter() {
+  public Function getWriter() {
     return writer;
   }
 

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/ConfigurationStep.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/ConfigurationStep.java
@@ -49,8 +49,8 @@ public class ConfigurationStep<M extends Message, R, W> {
    *
    * @return the new flow
    */
-  public FlowSpec<M, R, W> build() {
-    return new FlowSpec<>(
+  public FlowSpec build() {
+    return new FlowSpec(
         model.getReader(),
         model.getTransformer(),
         model.getWriter(),

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/ConfigurationStep.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/builder/ConfigurationStep.java
@@ -3,7 +3,9 @@ package com.github.dbmdz.flusswerk.framework.flow.builder;
 import com.github.dbmdz.flusswerk.framework.flow.FlowInfo;
 import com.github.dbmdz.flusswerk.framework.flow.FlowSpec;
 import com.github.dbmdz.flusswerk.framework.model.Message;
+import java.util.Collection;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Set configuration for the new flow and build it.
@@ -49,11 +51,12 @@ public class ConfigurationStep<M extends Message, R, W> {
    *
    * @return the new flow
    */
+  @SuppressWarnings("unchecked")
   public FlowSpec build() {
     return new FlowSpec(
-        model.getReader(),
-        model.getTransformer(),
-        model.getWriter(),
+        (Function<Message, Object>) model.getReader(),
+        (Function<Object, Object>) model.getTransformer(),
+        (Function<Object, Collection<Message>>) model.getWriter(),
         model.getCleanup(),
         model.getMetrics());
   }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/IncomingMessageType.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/IncomingMessageType.java
@@ -15,7 +15,7 @@ public class IncomingMessageType {
   }
 
   /**
-   * Provide a custom {@link Message} implmentation with default serialization and deserialization
+   * Provide a custom {@link Message} implementation with default serialization and deserialization
    * settings.
    *
    * @param cls the custom {@link Message} implementation
@@ -25,7 +25,7 @@ public class IncomingMessageType {
   }
 
   /**
-   * Provide a custom {@link Message} implmentation with custom serialization and deserialization
+   * Provide a custom {@link Message} implementation with custom serialization and deserialization
    * settings.
    *
    * @param cls custom {@link Message} implementation

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/engine/EngineTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/engine/EngineTest.java
@@ -97,7 +97,7 @@ class EngineTest {
   }
 
   @Test
-  @DisplayName("should stop with retry for RetriableProcessException")
+  @DisplayName("should stop with retry for RetryProcessException")
   void retryProcessExceptionShouldRejectTemporarily() throws IOException {
     Engine engine = createEngine(flowThrowing(RetryProcessingException.class));
     engine.process(message);

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/engine/EngineTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/engine/EngineTest.java
@@ -38,7 +38,7 @@ class EngineTest {
     message = new Message();
   }
 
-  private Engine createEngine(Flow<?, ?, ?> flow) {
+  private Engine createEngine(Flow flow) {
     return new Engine(messageBroker, flow, 5, new SilentProcessReport());
   }
 

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/exceptions/ExceptionSupplierTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/exceptions/ExceptionSupplierTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 class ExceptionSupplierTest {
 
   @Test
-  void shoudlSupplyExceptionWithOnlyMessage() {
+  void shouldSupplyExceptionWithOnlyMessage() {
     var supplier = new ExceptionSupplier<>(RetryProcessingException.class, "Hallo Welt", null);
     assertThat(supplier.get())
         .isInstanceOf(RetryProcessingException.class)
@@ -15,13 +15,13 @@ class ExceptionSupplierTest {
   }
 
   @Test
-  void shoudlSupplyStopProcessingExceptionWithOnlyMessage() {
+  void shouldSupplyStopProcessingExceptionWithOnlyMessage() {
     var supplier = new ExceptionSupplier<>(StopProcessingException.class, "Hallo Welt", null);
     assertThat(supplier.get()).isInstanceOf(StopProcessingException.class).hasMessage("Hallo Welt");
   }
 
   @Test
-  void shoudlSupplyExceptionWithMessageAndCause() {
+  void shouldSupplyExceptionWithMessageAndCause() {
     var supplier =
         new ExceptionSupplier<>(RetryProcessingException.class, "Hallo Welt", null)
             .causedBy(new RuntimeException("THE CAUSE"));
@@ -31,7 +31,7 @@ class ExceptionSupplierTest {
   }
 
   @Test
-  void shoudlSupplyStopProcessingExceptionWithMessageAndCause() {
+  void shouldSupplyStopProcessingExceptionWithMessageAndCause() {
     var supplier =
         new ExceptionSupplier<>(StopProcessingException.class, "Hallo Welt", null)
             .causedBy(new RuntimeException("THE CAUSE"));

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/fixtures/Flows.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/fixtures/Flows.java
@@ -14,8 +14,7 @@ public class Flows {
     return new Flow(spec, new NoOpLockManager());
   }
 
-  private static Flow flowWithTransformer(
-      Function<String, String> transformer) {
+  private static Flow flowWithTransformer(Function<String, String> transformer) {
     var spec =
         FlowBuilder.flow(Message.class, String.class, String.class)
             .reader(Message::getTracingId)

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/fixtures/Flows.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/fixtures/Flows.java
@@ -9,12 +9,12 @@ import java.util.function.Function;
 
 public class Flows {
 
-  public static Flow<Message, Message, Message> passthroughFlow() {
+  public static Flow passthroughFlow() {
     var spec = FlowBuilder.messageProcessor(Message.class).process(m -> m).build();
-    return new Flow<>(spec, new NoOpLockManager());
+    return new Flow(spec, new NoOpLockManager());
   }
 
-  private static Flow<Message, String, String> flowWithTransformer(
+  private static Flow flowWithTransformer(
       Function<String, String> transformer) {
     var spec =
         FlowBuilder.flow(Message.class, String.class, String.class)
@@ -22,10 +22,10 @@ public class Flows {
             .transformer(transformer)
             .writerSendingMessage(Message::new)
             .build();
-    return new Flow<>(spec, new NoOpLockManager());
+    return new Flow(spec, new NoOpLockManager());
   }
 
-  public static Flow<Message, String, String> flowThrowing(Class<? extends RuntimeException> cls) {
+  public static Flow flowThrowing(Class<? extends RuntimeException> cls) {
     var message = String.format("Generated %s for unit test", cls.getSimpleName());
     final RuntimeException exception;
     try {
@@ -43,7 +43,7 @@ public class Flows {
     return flowWithTransformer(transformerWithException);
   }
 
-  public static Flow<Message, String, String> flowBlockingAllThreads() {
+  public static Flow flowBlockingAllThreads() {
     return flowWithTransformer(new ThreadBlockingTransformer<>());
   }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/flow/builder/FlowBuilderTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/flow/builder/FlowBuilderTest.java
@@ -15,7 +15,7 @@ class FlowBuilderTest {
   @Test
   @DisplayName("should build a regular flow (using classes)")
   void shouldBuildRegularFlowUsingClasses() {
-    FlowSpec<Message, String, String> flow =
+    FlowSpec flow =
         FlowBuilder.flow(Message.class, String.class, String.class)
             .reader(Message::getTracingId)
             .transformer(String::toUpperCase)
@@ -27,7 +27,7 @@ class FlowBuilderTest {
   @Test
   @DisplayName("should build a regular flow (using types)")
   void shouldBuildRegularFlowUsingTypes() {
-    FlowSpec<Message, String, String> flow =
+    FlowSpec flow =
         FlowBuilder.flow(new Type<>() {}, new Type<String>() {}, new Type<String>() {})
             .reader(Message::getTracingId)
             .transformer(String::toUpperCase)
@@ -39,7 +39,7 @@ class FlowBuilderTest {
   @Test
   @DisplayName("should build a message processing flow sending a single message (using class)")
   void shouldBuildMessageProcessingFlowReturningSingleMessage() {
-    FlowSpec<Message, Message, Message> flow =
+    FlowSpec flow =
         FlowBuilder.messageProcessor(Message.class)
             .process(message -> new Message(message.getTracingId()))
             .build();
@@ -49,7 +49,7 @@ class FlowBuilderTest {
   @Test
   @DisplayName("should build a message processing flow sending a single message (using types)")
   void shouldBuildMessageProcessingFlowReturningSingleMessageUsingTypes() {
-    FlowSpec<Message, Message, Message> flow =
+    FlowSpec flow =
         FlowBuilder.messageProcessor(new Type<>() {})
             .process(message -> new Message(message.getTracingId()))
             .build();
@@ -59,7 +59,7 @@ class FlowBuilderTest {
   @Test
   @DisplayName("should build a message processing flow sending a multiple messages (using class)")
   void shouldBuildMessageProcessingFlowReturningManyMessages() {
-    FlowSpec<Message, Message, Message> flow =
+    FlowSpec flow =
         FlowBuilder.messageProcessor(Message.class)
             .expand(message -> List.of(message, message, message))
             .build();
@@ -69,7 +69,7 @@ class FlowBuilderTest {
   @Test
   @DisplayName("should build a message processing flow sending a multiple messages (using types)")
   void shouldBuildMessageProcessingFlowReturningManyMessagesUsingTypes() {
-    FlowSpec<Message, Message, Message> flow =
+    FlowSpec flow =
         FlowBuilder.messageProcessor(new Type<>() {})
             .expand(message -> List.of(message, message, message))
             .build();

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/RetryTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/RetryTest.java
@@ -87,7 +87,7 @@ public class RetryTest {
   static class FlowConfiguration {
 
     @Bean
-    public FlowSpec<Message, Message, Message> flowSpec() {
+    public FlowSpec flowSpec() {
       return FlowBuilder.messageProcessor(Message.class).process(new CountFailures()).build();
     }
   }

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/SuccessfulProcessingTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/SuccessfulProcessingTest.java
@@ -63,7 +63,7 @@ public class SuccessfulProcessingTest {
   @TestConfiguration
   static class FlowConfiguration {
     @Bean
-    public FlowSpec<Message, Message, Message> flowSpec() {
+    public FlowSpec flowSpec() {
       return FlowBuilder.messageProcessor(Message.class).process(m -> m).build();
     }
   }


### PR DESCRIPTION
After `FlowSpec` is created, both `FlowSpec` and `Flow` are only used internally. The typechecking for the use in Flusswerk apps is completely handled in the FlowBuilder. Therefore, removing generics from APIs makes it much easier to use Flusswerk.