### PR TITLE
Configure formatting as default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.github.dbmdz.flusswerk</groupId>
@@ -73,6 +75,8 @@
     <version.flusswerk>4.0.0-SNAPSHOT</version.flusswerk>
     <version.redisson>3.13.2</version.redisson>
     <!-- Plugin versions -->
+    <version.fmt-maven-plugin>2.10</version.fmt-maven-plugin>
+    <version.githook-maven-plugin>1.0.5</version.githook-maven-plugin>
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
     <version.maven-jacoco-plugin>0.8.5</version.maven-jacoco-plugin>
     <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
@@ -109,12 +113,30 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.10</version>
         <executions>
           <execution>
             <goals>
               <goal>format</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.github.phillipuniverse</groupId>
+        <artifactId>githook-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>install</goal>
+            </goals>
+            <configuration>
+              <hooks>
+                <pre-commit>
+                  echo running maven formatter
+                  exec mvn com.coveo:fmt-maven-plugin:format
+                </pre-commit>
+              </hooks>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -131,9 +153,19 @@
         <artifactId>nexus-staging-maven-plugin</artifactId>
       </plugin>
     </plugins>
-    
+
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>io.github.phillipuniverse</groupId>
+          <artifactId>githook-maven-plugin</artifactId>
+          <version>${version.githook-maven-plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>com.coveo</groupId>
+          <artifactId>fmt-maven-plugin</artifactId>
+          <version>${version.fmt-maven-plugin}</version>
+        </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>wagon-maven-plugin</artifactId>
@@ -152,7 +184,7 @@
               <format>html</format>
               <format>xml</format>
             </formats>
-            <check />
+            <check/>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Adds the versions of the Maven plugins for formatting and Git commit
hooks to plugin management and adds auto-formatting before commit for
the Flusswerk codebase.