### PR TITLE
Fix attempt to send messages when the Writer did not create one

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
@@ -130,7 +130,9 @@ public class Engine {
 
     // Data processing was successful, now handle the messaging
     try {
-      messageBroker.send(messagesToSend);
+      if (messagesToSend.size() > 0) {
+        messageBroker.send(messagesToSend);
+      }
       messageBroker.ack(message);
       processReport.reportSuccess(message);
     } catch (Exception e) {

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
@@ -130,7 +130,7 @@ public class Engine {
 
     // Data processing was successful, now handle the messaging
     try {
-      if (messagesToSend.size() > 0) {
+      if (!messagesToSend.isEmpty()) {
         messageBroker.send(messagesToSend);
       }
       messageBroker.ack(message);

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/engine/EngineTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/engine/EngineTest.java
@@ -1,8 +1,10 @@
 package com.github.dbmdz.flusswerk.framework.engine;
 
+import static com.github.dbmdz.flusswerk.framework.fixtures.Flows.consumingFlow;
 import static com.github.dbmdz.flusswerk.framework.fixtures.Flows.flowThrowing;
 import static com.github.dbmdz.flusswerk.framework.fixtures.Flows.passthroughFlow;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -86,6 +88,14 @@ class EngineTest {
 
     verify(messageBroker).ack(message);
     verify(messageBroker, never()).reject(message);
+  }
+
+  @Test
+  @DisplayName("should not try to send messages if the writer creates none")
+  void shouldNotTryToSendMessagesIfTheWriterCreatesNone() throws IOException {
+    Engine engine = createEngine(consumingFlow());
+    engine.process(new Message());
+    verify(messageBroker, never()).send(any());
   }
 
   @Test

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/fixtures/Flows.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/fixtures/Flows.java
@@ -14,6 +14,11 @@ public class Flows {
     return new Flow(spec, new NoOpLockManager());
   }
 
+  public static Flow consumingFlow() {
+    var spec = FlowBuilder.messageProcessor(Message.class).consume(m -> {}).build();
+    return new Flow(spec, new NoOpLockManager());
+  }
+
   private static Flow flowWithTransformer(Function<String, String> transformer) {
     var spec =
         FlowBuilder.flow(Message.class, String.class, String.class)


### PR DESCRIPTION
If the Writer is a Consumer, then there are no messages to send, and the application does not need to declare a default outgoing topic. The Framework should not attempt to start sending messages in that case and then fail if there is no default.