### PR TITLE
Fix default hosts

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/RabbitMQProperties.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/RabbitMQProperties.java
@@ -2,7 +2,6 @@ package com.github.dbmdz.flusswerk.framework.config.properties;
 
 import static java.util.Objects.requireNonNullElse;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.boot.context.properties.ConstructorBinding;
@@ -25,7 +24,7 @@ public class RabbitMQProperties {
    */
   public RabbitMQProperties(
       List<String> hosts, String virtualHost, String username, String password) {
-    this.hosts = requireNonNullElse(hosts, Collections.emptyList());
+    this.hosts = requireNotEmpty(hosts, List.of("localhost"));
     this.virtualHost = virtualHost; // can actually be null
     this.username = requireNonNullElse(username, "guest");
     this.password = requireNonNullElse(password, "guest");
@@ -64,5 +63,12 @@ public class RabbitMQProperties {
   public static RabbitMQProperties defaults() {
     // use null values so constructor sets defaults
     return new RabbitMQProperties(null, null, null, null);
+  }
+
+  private static <T> List<T> requireNotEmpty(List<T> list, List<T> defaultValues) {
+    if (list == null || list.isEmpty()) {
+      return defaultValues;
+    }
+    return list;
   }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/config/properties/RabbitMQPropertiesTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/config/properties/RabbitMQPropertiesTest.java
@@ -1,0 +1,27 @@
+package com.github.dbmdz.flusswerk.framework.config.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("The RabbitMQ properties")
+class RabbitMQPropertiesTest {
+
+  private static Stream<Arguments> defaultHosts() {
+    return Stream.of(Arguments.of((Object) null), Arguments.of(Collections.emptyList()));
+  }
+
+  @DisplayName("should default to localhost")
+  @ParameterizedTest
+  @MethodSource("defaultHosts")
+  void shouldDefaultToLocalhost(List<String> hosts) {
+    var properties = new RabbitMQProperties(hosts, null, null, null);
+    assertThat(properties.getHosts()).containsExactly("localhost");
+  }
+}


### PR DESCRIPTION
If the hosts entry in `application.yml` are missing, `localhost` should be used.