### PR TITLE
Introduce proper properties for app name

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -1,5 +1,6 @@
 package com.github.dbmdz.flusswerk.framework.config;
 
+import com.github.dbmdz.flusswerk.framework.config.properties.AppProperties;
 import com.github.dbmdz.flusswerk.framework.config.properties.FlusswerkProperties;
 import com.github.dbmdz.flusswerk.framework.config.properties.RedisProperties;
 import com.github.dbmdz.flusswerk.framework.engine.Engine;
@@ -26,7 +27,6 @@ import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -55,7 +55,7 @@ public class FlusswerkConfiguration {
    */
   @Bean
   public Engine engine(
-      @Value("spring.application.name") String name,
+      AppProperties appProperties,
       MessageBroker messageBroker,
       Flow flow,
       FlusswerkProperties flusswerkProperties,
@@ -72,7 +72,8 @@ public class FlusswerkConfiguration {
     }
 
     ProcessReport processReport =
-        processReportProvider.getIfAvailable(() -> new DefaultProcessReport(name));
+        processReportProvider.getIfAvailable(
+            () -> new DefaultProcessReport(appProperties.getName()));
     return new Engine(messageBroker, flow, threads, processReport);
   }
 
@@ -83,10 +84,10 @@ public class FlusswerkConfiguration {
 
   @Bean
   public MeterFactory meterFactory(
+      AppProperties appProperties,
       FlusswerkProperties flusswerkProperties,
-      @Value("spring.application.name") String name,
       MeterRegistry meterRegistry) {
-    return new MeterFactory(flusswerkProperties, name, meterRegistry);
+    return new MeterFactory(flusswerkProperties, appProperties.getName(), meterRegistry);
   }
 
   @Bean

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkPropertiesConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkPropertiesConfiguration.java
@@ -1,8 +1,9 @@
 package com.github.dbmdz.flusswerk.framework.config;
 
+import com.github.dbmdz.flusswerk.framework.config.properties.AppProperties;
 import com.github.dbmdz.flusswerk.framework.config.properties.FlusswerkProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 /** Separate config class for reading configuration properties to enable automated testing. */
-@EnableConfigurationProperties(FlusswerkProperties.class)
+@EnableConfigurationProperties({AppProperties.class, FlusswerkProperties.class})
 public class FlusswerkPropertiesConfiguration {}

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/AppProperties.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/AppProperties.java
@@ -1,0 +1,5 @@
+package com.github.dbmdz.flusswerk.framework.config.properties;
+
+public class AppProperties {
+
+}

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/AppProperties.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/AppProperties.java
@@ -1,5 +1,25 @@
 package com.github.dbmdz.flusswerk.framework.config.properties;
 
+import javax.validation.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.util.StringUtils;
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "spring.application")
 public class AppProperties {
 
+  private final String name;
+
+  public AppProperties(@NotEmpty String name) {
+    if (!StringUtils.hasText(name)) {
+      throw new RuntimeException(
+          "Any Flusswerk application needs to define spring.application.name");
+    }
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
 }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/RoutingProperties.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/RoutingProperties.java
@@ -40,7 +40,7 @@ public class RoutingProperties {
 
     this.failurePolicies =
         createFailurePolicies(
-            incoming, requireNonNullElseGet(failurePolicies, Collections::emptyMap));
+            this.incoming, requireNonNullElseGet(failurePolicies, Collections::emptyMap));
   }
 
   private static Map<String, FailurePolicy> createFailurePolicies(

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/MeterFactory.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/MeterFactory.java
@@ -7,7 +7,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.springframework.beans.factory.annotation.Value;
 
 /** Convenience factory to simplify the creation of {@link Counter} meters. */
 public class MeterFactory {
@@ -21,10 +20,7 @@ public class MeterFactory {
    * @param app The app name to add as a tag to all metrics
    * @param registry the Micrometer registry to create the counters
    */
-  public MeterFactory(
-      FlusswerkProperties flusswerkProperties,
-      @Value("${spring.application.name}") String app,
-      MeterRegistry registry) {
+  public MeterFactory(FlusswerkProperties flusswerkProperties, String app, MeterRegistry registry) {
     this.basename = flusswerkProperties.getMonitoring().getPrefix();
     this.app = app;
     this.registry = registry;

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/config/properties/AppPropertiesTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/config/properties/AppPropertiesTest.java
@@ -1,0 +1,36 @@
+package com.github.dbmdz.flusswerk.framework.config.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.dbmdz.flusswerk.framework.config.FlusswerkPropertiesConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(classes = FlusswerkPropertiesConfiguration.class)
+public class AppPropertiesTest {
+
+  @Autowired private AppProperties properties;
+
+  @DisplayName("should have application name")
+  @Test
+  void shouldHaveAppNameFromApplicationYaml() {
+    assertThat(properties.getName()).isEqualTo("flusswerk.test");
+  }
+
+  @DisplayName("should never have empty application name")
+  @ParameterizedTest(name = "name=\"{0}\"")
+  @NullSource
+  @ValueSource(strings = {"", " \t"})
+  void shouldNeverHaveEmptyAppName(String name) {
+    assertThatThrownBy(() -> new AppProperties(name))
+        .hasMessageContaining("needs to define spring.application.name");
+  }
+}

--- a/framework/src/test/resources/application.yml
+++ b/framework/src/test/resources/application.yml
@@ -1,3 +1,8 @@
+spring:
+  application:
+    name: flusswerk.test
+
+
 flusswerk:
   processing:
     threads: 5


### PR DESCRIPTION
The Spring Boot application name is used for monitoring and logging, but implementation had bugs. This MR now introduces a proper ConfigurationProperties class for `spring.application.name`.