### PR TITLE
Fix wrong Message.hashCode

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Message.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Message.java
@@ -60,6 +60,6 @@ public class Message {
 
   @Override
   public int hashCode() {
-    return Objects.hash(envelope, tracingId);
+    return Objects.hash(tracingId);
   }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/model/MessageTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/model/MessageTest.java
@@ -1,7 +1,6 @@
 package com.github.dbmdz.flusswerk.framework.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -25,5 +24,12 @@ class MessageTest {
   @MethodSource("messages")
   void testEquals(Message m1, Message m2, boolean shouldBeEqual) {
     assertThat(m1.equals(m2)).isEqualTo(shouldBeEqual);
+  }
+
+  @DisplayName("should be have the same hashCode as another message with the same tracing id")
+  @ParameterizedTest
+  @MethodSource("messages")
+  void testHashCode(Message m1, Message m2, boolean shouldBeEqual) {
+    assertThat(m1.hashCode() == m2.hashCode()).isEqualTo(shouldBeEqual);
   }
 }


### PR DESCRIPTION
Both `equals() `and _hashCode()_ have to consider the same fields. Since the purpose of `Envelope` is to contain the information the framework needs to manage the processing, it should not be included.

