### PR TITLE
Snapshot-Deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build with Maven
-        run: mvn -B verify
-      - name: Integration Tests
-        run: mvn -B --projects integration-tests -Pintegration surefire:test
+        run: mvn -B -Pintegration verify
       - name: Report Coverage
         uses: codecov/codecov-action@v1
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,3 +32,12 @@ integration_tests:openjdk12:
   only:
     variables:
       - $USE_OPENJDK12
+
+publish_snapshot:
+  extends: .publish
+  only:
+    - main
+    - master
+  script:
+    - if [[ ! "$PROJECT_VERSION" =~ .*SNAPSHOT ]]; then exit 0; fi
+    - mvn $MAVEN_CLI_OPTS -T 4 deploy -DskipTests -Pmaven-central --settings settings.xml

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.dbmdz.flusswerk</groupId>
   <artifactId>flusswerk</artifactId>
-  <version>4.0.0</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Flusswerk</name>
@@ -71,7 +71,7 @@
     <!-- Dependency versions -->
     <version.amqp-client>5.6.0</version.amqp-client>
     <version.logstash-encoder>6.4</version.logstash-encoder>
-    <version.flusswerk>4.0.0</version.flusswerk>
+    <version.flusswerk>4.0.1-SNAPSHOT</version.flusswerk>
     <version.redisson>3.13.3</version.redisson>
     <!-- Plugin versions -->
     <version.fmt-maven-plugin>2.10</version.fmt-maven-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -153,10 +153,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -255,7 +251,7 @@
 
   <profiles>
     <profile>
-      <id>deploy</id>
+      <id>maven-central</id>
       <build>
         <plugins>
           <plugin>
@@ -271,6 +267,10 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Flusswerk 4 recommends to use the Flusswerk 4 parent pom for workflow jobs. This caused the Nexus Staging Maven Plugin to be part of any workflow job, interfering with existing deployment strategies.

To solve this, a new maven profile `maven-central` was introduced (replacing the `deploy` profile) to explicitely use the Nexus Staging Plugin in the deployment build.