### PR TITLE
Cache maven dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
       - name: Build with Maven
         run: mvn -B verify
       - name: Integration Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
+        env:
+          cache-name: cache-maven-artifacts
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -14,7 +14,11 @@ jobs:
           server-id: ossrh-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-      - name: Deploy to Sonatype Snapshots
+    - uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+    - name: Deploy to Sonatype Snapshots
         run: mvn -B verify
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -14,8 +14,10 @@ jobs:
           server-id: ossrh-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-    - uses: actions/cache@v1
-      with:
+      - uses: actions/cache@v2
+        env:
+          cache-name: cache-maven-artifacts
+        with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
     - name: Deploy to Sonatype Snapshots


### PR DESCRIPTION
Builds with the same pom can safely cache `.m2/repository` to speed up builds.