### PR TITLE
Fix GitHub Actions YAML for Snapshots

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -18,8 +18,8 @@ jobs:
         env:
           cache-name: cache-maven-artifacts
         with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
     - name: Deploy to Sonatype Snapshots
         run: mvn -B verify
         env:


### PR DESCRIPTION
The new caching action was missing indents, therefore leading to an invalid configuration.