### PR TITLE
Fix Snapshot deployments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,17 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>sign</id>
+      <build>
+        <plugins>
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>${version.maven-gpg-plugin}</version>
@@ -267,10 +278,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Maven parent projects cannot configure default deployment, as this would set the deployment for every child project as well. A separate Maven profile for deployment for maven central sets the target, and another profile can be invoked to activate signing.

Deployment of a Snapshot:
```
mvn deploy -P maven-central
```

Deployment of a Release:
```
mvn deploy -P maven-central,sign
```


