### PR TITLE
Refactor JSON handling to FlusswerkObjectMapper

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -9,6 +9,7 @@ import com.github.dbmdz.flusswerk.framework.config.properties.RoutingProperties;
 import com.github.dbmdz.flusswerk.framework.engine.Engine;
 import com.github.dbmdz.flusswerk.framework.flow.Flow;
 import com.github.dbmdz.flusswerk.framework.flow.FlowSpec;
+import com.github.dbmdz.flusswerk.framework.jackson.FlusswerkObjectMapper;
 import com.github.dbmdz.flusswerk.framework.locking.LockManager;
 import com.github.dbmdz.flusswerk.framework.locking.NoOpLockManager;
 import com.github.dbmdz.flusswerk.framework.locking.RedisLockManager;
@@ -87,6 +88,12 @@ public class FlusswerkConfiguration {
   }
 
   @Bean
+  public FlusswerkObjectMapper flusswerkObjectMapper(
+      ObjectProvider<IncomingMessageType> incomingMessageType) {
+    return new FlusswerkObjectMapper(incomingMessageType.getIfAvailable(IncomingMessageType::new));
+  }
+
+  @Bean
   public RabbitConnection rabbitConnection(RabbitMQProperties rabbitMQProperties)
       throws IOException {
     return new RabbitConnection(rabbitMQProperties);
@@ -94,9 +101,8 @@ public class FlusswerkConfiguration {
 
   @Bean
   public RabbitClient rabbitClient(
-      ObjectProvider<IncomingMessageType> incomingMessageType, RabbitConnection rabbitConnection) {
-    return new RabbitClient(
-        incomingMessageType.getIfAvailable(IncomingMessageType::new), rabbitConnection);
+      FlusswerkObjectMapper flusswerkObjectMapper, RabbitConnection rabbitConnection) {
+    return new RabbitClient(flusswerkObjectMapper, rabbitConnection);
   }
 
   @Bean

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/jackson/FlusswerkObjectMapper.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/jackson/FlusswerkObjectMapper.java
@@ -1,0 +1,28 @@
+package com.github.dbmdz.flusswerk.framework.jackson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.dbmdz.flusswerk.framework.model.Envelope;
+import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
+import com.github.dbmdz.flusswerk.framework.model.Message;
+
+public class FlusswerkObjectMapper extends ObjectMapper {
+
+  private final Class<? extends Message> messageClass;
+
+  public FlusswerkObjectMapper(IncomingMessageType incomingMessageType) {
+    messageClass = incomingMessageType.getMessageClass();
+    if (incomingMessageType.hasMixin()) {
+      addMixIn(incomingMessageType.getMessageClass(), incomingMessageType.getMixin());
+    } else {
+      addMixIn(Message.class, DefaultMixin.class);
+    }
+    addMixIn(Envelope.class, EnvelopeMixin.class);
+    registerModule(new JavaTimeModule());
+  }
+
+  public Message deserialize(String json) throws JsonProcessingException {
+    return readValue(json, messageClass);
+  }
+}

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/jackson/DefaultMixinTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/jackson/DefaultMixinTest.java
@@ -4,10 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.dbmdz.flusswerk.framework.TestMessage;
-import com.github.dbmdz.flusswerk.framework.model.Envelope;
+import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.model.Message;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,13 +18,7 @@ class DefaultMixinTest {
 
   @BeforeEach
   void setUp() {
-    objectMapper =
-        new ObjectMapper()
-            .addMixIn(Message.class, DefaultMixin.class)
-            .addMixIn(Envelope.class, EnvelopeMixin.class)
-            .registerModule(new JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-            .enable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS);
+    objectMapper = new FlusswerkObjectMapper(new IncomingMessageType());
   }
 
   @Test

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/jackson/DefaultMixinTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/jackson/DefaultMixinTest.java
@@ -3,7 +3,6 @@ package com.github.dbmdz.flusswerk.framework.jackson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dbmdz.flusswerk.framework.TestMessage;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.model.Message;
@@ -14,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 class DefaultMixinTest {
 
-  private ObjectMapper objectMapper;
+  private FlusswerkObjectMapper objectMapper;
 
   @BeforeEach
   void setUp() {


### PR DESCRIPTION
We introduce a FlusswerkObjectMapper that builds upon a Jackson
ObjectMapper but includes all Flusswerk specific configurations and a
method to deserialize JSON to Message directly. This does not only
simplify the architecture, but should makes testing more flexible and
powerful.