### PR TITLE
Enable message-specific metrics

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
@@ -47,7 +47,7 @@ public class Flow {
   }
 
   public Collection<Message> process(Message message) {
-    FlowInfo info = new FlowInfo();
+    FlowInfo info = new FlowInfo(message);
     Collection<Message> result;
 
     setLoggingData(message);

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/FlowInfo.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/FlowInfo.java
@@ -2,6 +2,7 @@ package com.github.dbmdz.flusswerk.framework.flow;
 
 import com.github.dbmdz.flusswerk.framework.exceptions.StopProcessingException;
 import com.github.dbmdz.flusswerk.framework.flow.builder.ConfigurationStep;
+import com.github.dbmdz.flusswerk.framework.model.Message;
 
 /**
  * Collect base metrics for a single flow - did the execution have errors and how long does it take?
@@ -18,14 +19,14 @@ public class FlowInfo {
   }
 
   private final long startTime;
-
   private long endTime;
-
   private Status status;
+  private final Message message;
 
-  public FlowInfo() {
+  public FlowInfo(Message message) {
     this.startTime = System.currentTimeMillis();
     this.status = Status.SUCCESS;
+    this.message = message;
   }
 
   public void stop() {
@@ -42,6 +43,10 @@ public class FlowInfo {
     } else {
       status = Status.ERROR_RETRY;
     }
+  }
+
+  public Message getMessage() {
+    return message;
   }
 
   public long duration() {


### PR DESCRIPTION
For some cases (like different data sources) it can be useful to use information from the message to calculate or label metrics. This MR makes the processed Message instance available where metrics are calculated.