### PR TITLE
Make FlowMetrics more flexible

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -16,7 +16,7 @@ import com.github.dbmdz.flusswerk.framework.locking.LockManager;
 import com.github.dbmdz.flusswerk.framework.locking.NoOpLockManager;
 import com.github.dbmdz.flusswerk.framework.locking.RedisLockManager;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
-import com.github.dbmdz.flusswerk.framework.monitoring.BaseMetrics;
+import com.github.dbmdz.flusswerk.framework.monitoring.DefaultFlowMetrics;
 import com.github.dbmdz.flusswerk.framework.monitoring.FlowMetrics;
 import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
@@ -66,10 +66,15 @@ public class FlusswerkConfiguration {
       Optional<Flow> flow,
       ProcessingProperties processingProperties,
       Optional<ProcessReport> processReport,
-      Set<FlowMetrics> flowMetrics) {
+      Set<FlowMetrics> flowMetrics,
+      MeterFactory meterFactory) {
 
     if (flow.isEmpty()) {
       return new NoOpEngine(); // No Flow, nothing to do
+    }
+
+    if (flowMetrics.isEmpty()) {
+      new DefaultFlowMetrics(meterFactory);
     }
 
     flow.get().registerFlowMetrics(flowMetrics);
@@ -80,11 +85,6 @@ public class FlusswerkConfiguration {
     var threads = processingProperties.getThreads();
 
     return new DefaultEngine(messageBroker, flow.get(), threads, actualProcessReport);
-  }
-
-  @Bean
-  public BaseMetrics baseMetrics(MeterFactory meterFactory) {
-    return new BaseMetrics(meterFactory);
   }
 
   @Bean

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -73,8 +73,9 @@ public class FlusswerkConfiguration {
       return new NoOpEngine(); // No Flow, nothing to do
     }
 
+    // Use DefaultFlowMetrics only if there are no other FlowMetrics beans defined in the app
     if (flowMetrics.isEmpty()) {
-      new DefaultFlowMetrics(meterFactory);
+      flowMetrics.add(new DefaultFlowMetrics(meterFactory));
     }
 
     flow.get().registerFlowMetrics(flowMetrics);

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/BaseMetrics.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/BaseMetrics.java
@@ -1,0 +1,13 @@
+package com.github.dbmdz.flusswerk.framework.monitoring;
+
+/**
+ * Class remains until next major release for API compatibility in case an app used this for
+ * implementing monitoring features.
+ */
+@Deprecated
+public class BaseMetrics extends DefaultFlowMetrics {
+
+  public BaseMetrics(MeterFactory meterFactory) {
+    super(meterFactory);
+  }
+}

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/DefaultFlowMetrics.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/DefaultFlowMetrics.java
@@ -6,13 +6,16 @@ import io.micrometer.core.instrument.Counter;
 import java.util.EnumMap;
 import java.util.Map;
 
-/** Collect metrics on flow execution. */
-public class BaseMetrics implements FlowMetrics {
+/**
+ * Collect metrics on flow execution. This implementation is default if there are no other
+ * FlowMetrics beans defined. You can define as many FlowMetrics beans as needed.
+ */
+public class DefaultFlowMetrics implements FlowMetrics {
 
   private final Map<Status, Counter> executionTime;
   private final Map<Status, Counter> processedItems;
 
-  public BaseMetrics(MeterFactory meterFactory) {
+  public DefaultFlowMetrics(MeterFactory meterFactory) {
     this.executionTime = new EnumMap<>(Status.class);
     this.processedItems = new EnumMap<>(Status.class);
 

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/monitoring/BaseMetricsTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/monitoring/BaseMetricsTest.java
@@ -31,7 +31,7 @@ class BaseMetricsTest {
   @MethodSource("counters")
   void shouldInitializeCounters(String metric, Status status) {
     MeterFactory meterFactory = mock(MeterFactory.class);
-    new BaseMetrics(meterFactory);
+    new DefaultFlowMetrics(meterFactory);
     verify(meterFactory).counter(metric, status);
   }
 
@@ -41,7 +41,7 @@ class BaseMetricsTest {
     MeterFactory meterFactory = mock(MeterFactory.class);
     Counter counter = mock(Counter.class);
     when(meterFactory.counter(any(), eq(Status.SUCCESS))).thenReturn(counter);
-    BaseMetrics baseMetrics = new BaseMetrics(meterFactory);
+    DefaultFlowMetrics baseMetrics = new DefaultFlowMetrics(meterFactory);
 
     FlowInfo flowInfo = mock(FlowInfo.class);
     when(flowInfo.getStatus()).thenReturn(Status.SUCCESS);

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/monitoring/DefaultFlowMetricsTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/monitoring/DefaultFlowMetricsTest.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@DisplayName("The BaseMetrics")
-class BaseMetricsTest {
+@DisplayName("The DefaultFlowMetrics")
+class DefaultFlowMetricsTest {
 
   private static Stream<Arguments> counters() {
     return Stream.concat(
@@ -41,11 +41,11 @@ class BaseMetricsTest {
     MeterFactory meterFactory = mock(MeterFactory.class);
     Counter counter = mock(Counter.class);
     when(meterFactory.counter(any(), eq(Status.SUCCESS))).thenReturn(counter);
-    DefaultFlowMetrics baseMetrics = new DefaultFlowMetrics(meterFactory);
+    DefaultFlowMetrics defaultFlowMetrics = new DefaultFlowMetrics(meterFactory);
 
     FlowInfo flowInfo = mock(FlowInfo.class);
     when(flowInfo.getStatus()).thenReturn(Status.SUCCESS);
-    baseMetrics.accept(flowInfo);
+    defaultFlowMetrics.accept(flowInfo);
     verify(flowInfo).duration();
     verify(flowInfo).getStatus();
   }


### PR DESCRIPTION
With this PR you can simply replace the DefaultFlowMetrics so that you can e.g. add specific tags to item count or time used.