### PR TITLE
Remove extra timestamp

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>4.1.1</version>
+    <version>4.1.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Envelope.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Envelope.java
@@ -81,6 +81,7 @@ public class Envelope {
    *
    * @return The timestamp when the message was created.
    */
+  @Deprecated
   public LocalDateTime getTimestamp() {
     return timestamp;
   }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/reporting/StructuredProcessReport.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/reporting/StructuredProcessReport.java
@@ -6,7 +6,6 @@ import static net.logstash.logback.argument.StructuredArguments.keyValue;
 import com.github.dbmdz.flusswerk.framework.exceptions.StopProcessingException;
 import com.github.dbmdz.flusswerk.framework.model.Envelope;
 import com.github.dbmdz.flusswerk.framework.model.Message;
-import java.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +36,6 @@ public class StructuredProcessReport implements ProcessReport {
             keyValue("will_retry", false),
             keyValue("incoming_queue", envelope.getSource()),
             keyValue("retries", envelope.getRetries()),
-            keyValue("timestamp", envelope.getTimestamp().format(DateTimeFormatter.ISO_DATE_TIME)),
             keyValue("tracing_id", message.getTracingId()),
             keyValue("tracing", tracing.tracingPath()),
             e);
@@ -53,7 +51,6 @@ public class StructuredProcessReport implements ProcessReport {
             keyValue("will_retry", false),
             keyValue("incoming_queue", envelope.getSource()),
             keyValue("retries", envelope.getRetries()),
-            keyValue("timestamp", envelope.getTimestamp().format(DateTimeFormatter.ISO_DATE_TIME)),
             keyValue("tracing_id", message.getTracingId()),
             keyValue("tracing", tracing.tracingPath()),
             e);
@@ -69,7 +66,6 @@ public class StructuredProcessReport implements ProcessReport {
             keyValue("will_retry", true),
             keyValue("incoming_queue", envelope.getSource()),
             keyValue("retries", envelope.getRetries()),
-            keyValue("timestamp", envelope.getTimestamp().format(DateTimeFormatter.ISO_DATE_TIME)),
             keyValue("tracing_id", message.getTracingId()),
             keyValue("tracing", tracing.tracingPath()),
             e);

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>4.1.1</version>
+    <version>4.1.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.dbmdz.flusswerk</groupId>
   <artifactId>flusswerk</artifactId>
-  <version>4.1.1</version>
+  <version>4.1.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Flusswerk</name>
@@ -71,7 +71,7 @@
     <!-- Dependency versions -->
     <version.amqp-client>5.6.0</version.amqp-client>
     <version.logstash-encoder>6.4</version.logstash-encoder>
-    <version.flusswerk>4.1.1</version.flusswerk>
+    <version.flusswerk>4.1.2-SNAPSHOT</version.flusswerk>
     <version.redisson>3.13.5</version.redisson>
     <!-- Plugin versions -->
     <version.fmt-maven-plugin>2.10</version.fmt-maven-plugin>


### PR DESCRIPTION
Logging had a timestamp field that was derived from when the message was first created. This is more confusing than useful and will therefore be removed.