### PR TITLE
Fix order of logger arguments

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/reporting/FlusswerkLogger.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/reporting/FlusswerkLogger.java
@@ -68,7 +68,12 @@ public class FlusswerkLogger {
   Object[] addTracing(Object[] arguments) {
     Object[] extended = new Object[arguments.length + 1];
     System.arraycopy(arguments, 0, extended, 0, arguments.length);
-    extended[extended.length - 1] = keyValue("tracing", tracing.tracingPath());
+    if (arguments[arguments.length - 1] instanceof Throwable) {
+      extended[extended.length - 1] = arguments[arguments.length - 1];
+      extended[extended.length - 2] = keyValue("tracing", tracing.tracingPath());
+    } else {
+      extended[extended.length - 1] = keyValue("tracing", tracing.tracingPath());
+    }
     return extended;
   }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/reporting/FlusswerkLoggerTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/reporting/FlusswerkLoggerTest.java
@@ -4,11 +4,13 @@ import static net.logstash.logback.argument.StructuredArguments.keyValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import net.logstash.logback.argument.StructuredArgument;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +35,15 @@ class FlusswerkLoggerTest {
   void error() {
     flusswerkLogger.error("format string", "a");
     verify(logger).error(anyString(), (Object[]) any());
+  }
+
+  @DisplayName("should move Throwable to the end")
+  @Test
+  void shouldMoveThrowableToTheEnd() {
+    var throwable = mock(Throwable.class);
+    flusswerkLogger.error("format string", "a", throwable);
+    verify(logger)
+        .error(eq("format string"), eq("a"), any(StructuredArgument.class), eq(throwable));
   }
 
   @DisplayName("should use warn logging")


### PR DESCRIPTION
Throwables must be the last in a list of arguments. This MR ensures that the behaviour of `FlusswerkLogger.error(String, Object...)` (and the other log levels) is equal to the corresponding methods of SLF4J and Logback.