### PR TITLE
 Add application name to RabbitMQ connection

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>4.2.0</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -111,9 +111,9 @@ public class FlusswerkConfiguration {
   }
 
   @Bean
-  public RabbitConnection rabbitConnection(RabbitMQProperties rabbitMQProperties)
-      throws IOException {
-    return new RabbitConnection(rabbitMQProperties);
+  public RabbitConnection rabbitConnection(
+      AppProperties appProperties, RabbitMQProperties rabbitMQProperties) throws IOException {
+    return new RabbitConnection(rabbitMQProperties, appProperties.getName());
   }
 
   @Bean

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitConnection.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitConnection.java
@@ -20,16 +20,19 @@ public class RabbitConnection {
   private final ConnectionFactory factory;
 
   private Channel channel;
+  private final String appName;
 
   private final RabbitMQProperties rabbitMQ;
 
-  public RabbitConnection(RabbitMQProperties rabbitMQ) throws IOException {
-    this(rabbitMQ, new ConnectionFactory());
+  public RabbitConnection(RabbitMQProperties rabbitMQ, String appName) throws IOException {
+    this(rabbitMQ, new ConnectionFactory(), appName);
   }
 
-  RabbitConnection(RabbitMQProperties rabbitMQ, ConnectionFactory factory) throws IOException {
+  RabbitConnection(RabbitMQProperties rabbitMQ, ConnectionFactory factory, String appName)
+      throws IOException {
     this.rabbitMQ = rabbitMQ;
     this.factory = factory;
+    this.appName = appName;
     factory.setUsername(rabbitMQ.getUsername());
     factory.setPassword(rabbitMQ.getPassword());
     rabbitMQ.getVirtualHost().ifPresent(factory::setVirtualHost);
@@ -54,7 +57,7 @@ public class RabbitConnection {
     while (connectionIsFailing) {
       try {
         LOGGER.debug("Waiting for connection to {} ...", addresses);
-        com.rabbitmq.client.Connection connection = factory.newConnection(addresses);
+        com.rabbitmq.client.Connection connection = factory.newConnection(addresses, appName);
         channel = connection.createChannel();
         channel.basicRecover(true);
         connectionIsFailing = false;

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitConnection.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitConnection.java
@@ -3,6 +3,7 @@ package com.github.dbmdz.flusswerk.framework.rabbitmq;
 import com.github.dbmdz.flusswerk.framework.config.properties.RabbitMQProperties;
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import java.io.IOException;
 import java.util.List;
@@ -57,7 +58,7 @@ public class RabbitConnection {
     while (connectionIsFailing) {
       try {
         LOGGER.debug("Waiting for connection to {} ...", addresses);
-        com.rabbitmq.client.Connection connection = factory.newConnection(addresses, appName);
+        Connection connection = factory.newConnection(addresses, appName);
         channel = connection.createChannel();
         channel.basicRecover(true);
         connectionIsFailing = false;

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>4.2.0</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.dbmdz.flusswerk</groupId>
   <artifactId>flusswerk</artifactId>
-  <version>4.2.0</version>
+  <version>4.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Flusswerk</name>
@@ -71,7 +71,7 @@
     <!-- Dependency versions -->
     <version.amqp-client>5.6.0</version.amqp-client>
     <version.logstash-encoder>6.4</version.logstash-encoder>
-    <version.flusswerk>4.2.0</version.flusswerk>
+    <version.flusswerk>4.3.0-SNAPSHOT</version.flusswerk>
     <version.redisson>3.13.6</version.redisson>
     <!-- Plugin versions -->
     <version.fmt-maven-plugin>2.10</version.fmt-maven-plugin>


### PR DESCRIPTION
The application name is displayed next to the connection in the RabbitMQ management view. The application name is only extra information for ops, not an unique identifier - multiple instances can report the same name.