### PR TITLE
Refactor properties string representation

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/AppProperties.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/AppProperties.java
@@ -22,4 +22,9 @@ public class AppProperties {
   public String getName() {
     return name;
   }
+
+  @Override
+  public String toString() {
+    return StringRepresentation.of(this);
+  }
 }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/FlusswerkProperties.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/FlusswerkProperties.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
 
 /** Model for the configuration parameters in <code>application.yml</code>. */
 @ConstructorBinding
@@ -22,6 +24,8 @@ public class FlusswerkProperties {
 
   @NestedConfigurationProperty private final RedisProperties redis;
 
+  private final Yaml yaml;
+
   @ConstructorBinding
   public FlusswerkProperties(
       ProcessingProperties processing,
@@ -34,6 +38,9 @@ public class FlusswerkProperties {
     this.routing = requireNonNullElseGet(routing, RoutingProperties::defaults);
     this.monitoring = requireNonNullElseGet(monitoring, MonitoringProperties::defaults);
     this.redis = redis; // might actually be null, then centralized locking will be disabled
+    DumperOptions options = new DumperOptions();
+    options.setAllowReadOnlyProperties(true);
+    yaml = new Yaml(options);
   }
 
   public ProcessingProperties getProcessing() {
@@ -58,11 +65,6 @@ public class FlusswerkProperties {
 
   @Override
   public String toString() {
-    return StringRepresentation.of(FlusswerkProperties.class)
-        .property("processing", processing.toString())
-        .property("routing", routing.toString())
-        .property("connection", rabbitmq.toString())
-        .property("monitoring", monitoring.toString())
-        .toString();
+    return StringRepresentation.of(this);
   }
 }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/MonitoringProperties.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/MonitoringProperties.java
@@ -21,9 +21,7 @@ public class MonitoringProperties {
 
   @Override
   public String toString() {
-    return StringRepresentation.of(MonitoringProperties.class)
-        .property("prefix", prefix)
-        .toString();
+    return StringRepresentation.of(this);
   }
 
   public static MonitoringProperties defaults() {

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/ProcessingProperties.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/ProcessingProperties.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNullElse;
 import javax.validation.constraints.Min;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
+import org.yaml.snakeyaml.Yaml;
 
 /** Configuration related to the processing. */
 @ConstructorBinding
@@ -25,9 +26,8 @@ public class ProcessingProperties {
 
   @Override
   public String toString() {
-    return StringRepresentation.of(ProcessingProperties.class)
-        .property("threads", threads)
-        .toString();
+    Yaml yaml = new Yaml();
+    return yaml.dump(this);
   }
 
   public static ProcessingProperties defaults() {

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/RabbitMQProperties.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/RabbitMQProperties.java
@@ -54,12 +54,7 @@ public class RabbitMQProperties {
 
   @Override
   public String toString() {
-    return StringRepresentation.of(RabbitMQProperties.class)
-        .property("hosts", hosts)
-        .property("virtualHost", virtualHost)
-        .property("username", username)
-        .maskedProperty("password", password)
-        .toString();
+    return StringRepresentation.of(this).replace(password, "*****");
   }
 
   public static RabbitMQProperties defaults() {

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/RedisProperties.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/RedisProperties.java
@@ -69,4 +69,9 @@ public class RedisProperties {
   public String getKeyspace() {
     return keyspace;
   }
+
+  @Override
+  public String toString() {
+    return StringRepresentation.of(this).replace(password, "*****");
+  }
 }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/RoutingProperties.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/RoutingProperties.java
@@ -149,11 +149,7 @@ public class RoutingProperties {
 
   @Override
   public String toString() {
-    return StringRepresentation.of(RoutingProperties.class)
-        .property("exchange", defaultExchange)
-        .property("readFrom", String.join(",", incoming))
-        .property("writeTo", outgoing)
-        .toString();
+    return StringRepresentation.of(this);
   }
 
   public FailurePolicy getFailurePolicy(Message message) {

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/StringRepresentation.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/properties/StringRepresentation.java
@@ -1,125 +1,23 @@
 package com.github.dbmdz.flusswerk.framework.config.properties;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
 
 /** Creates a nice string representation for hierarchical data structures. */
 class StringRepresentation {
 
-  private final StringBuilder stringBuilder;
+  private static final StringRepresentation INSTANCE = new StringRepresentation();
 
-  private StringRepresentation(String name) {
-    stringBuilder = new StringBuilder(name);
-    newline();
+  private final Yaml yaml;
+
+  private StringRepresentation() {
+    DumperOptions options = new DumperOptions();
+    options.setAllowReadOnlyProperties(true);
+    options.setAllowUnicode(true);
+    yaml = new Yaml(options);
   }
 
-  public static StringRepresentation of(Class<?> cls) {
-    return new StringRepresentation(cls.getSimpleName());
-  }
-
-  public StringRepresentation property(String name, int value) {
-    return property(name, Integer.toString(value));
-  }
-
-  /**
-   * Add a property as key-value-pair with proper indentation.
-   *
-   * @param name The properties name.
-   * @param value The properties value.
-   * @return The <code>StringRepresentation</code> object to allow fluent method chaining.
-   */
-  public StringRepresentation property(String name, String value) {
-    if (value == null) {
-      value = "null";
-    }
-    indent();
-    text(name);
-    text(":");
-    indent();
-    if (value.contains("\n")) {
-      newline();
-      for (String line : value.split("\n")) {
-        indent();
-        text(line);
-        newline();
-      }
-    } else {
-      text(value);
-      newline();
-    }
-
-    return this;
-  }
-
-  public StringRepresentation property(String name, Map<String, String> values) {
-    if (values == null) {
-      property(name, "null");
-      return this;
-    }
-    indent();
-    text(name);
-    text(":");
-    newline();
-    List<String> keys = new ArrayList<>(values.keySet());
-    Collections.sort(keys);
-    for (String key : keys) {
-      indent();
-      property(key, values.get(key));
-    }
-    return this;
-  }
-
-  private void indent() {
-    stringBuilder.append("\t");
-  }
-
-  private void newline() {
-    stringBuilder.append("\n");
-  }
-
-  private void text(String value) {
-    stringBuilder.append(value);
-  }
-
-  public String toString() {
-    return stringBuilder.toString();
-  }
-
-  /**
-   * Creates a masked version of the property, hiding all but the first letter. The remaining
-   * letters are replaced by exactly five "*" characters to conceal the value's true length.
-   *
-   * @param name The properties name.
-   * @param value The properties value.
-   * @return The <code>StringRepresentation</code> object to allow fluent method chaining.
-   */
-  public StringRepresentation maskedProperty(String name, String value) {
-    stringBuilder.append("\n\t");
-    stringBuilder.append(name);
-    stringBuilder.append(":\t");
-    stringBuilder.append(value, 0, 1);
-    stringBuilder.append("*".repeat(5)); // Fixed number of stars to hide real password length
-    return this;
-  }
-
-  public StringRepresentation property(String name, List<String> values) {
-    if (values == null) {
-      property(name, "null");
-      return this;
-    }
-    indent();
-    text(name);
-    text(":");
-    newline();
-    for (String value : values) {
-      indent();
-      indent();
-      text("- ");
-      text(value);
-      newline();
-    }
-    return this;
+  public static String of(Object o) {
+    return INSTANCE.yaml.dump(o);
   }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/config/properties/FlusswerkPropertiesTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/config/properties/FlusswerkPropertiesTest.java
@@ -52,4 +52,11 @@ public class FlusswerkPropertiesTest {
         .hasFieldOrPropertyWithValue("retryRoutingKey", "first.custom.retry")
         .hasFieldOrPropertyWithValue("failedRoutingKey", "first.custom.failed");
   }
+
+  @Test
+  void testToString() {
+    String yaml = properties.toString();
+    System.out.println(yaml);
+    assertThat(yaml).isEqualTo("");
+  }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/config/properties/FlusswerkPropertiesTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/config/properties/FlusswerkPropertiesTest.java
@@ -52,11 +52,4 @@ public class FlusswerkPropertiesTest {
         .hasFieldOrPropertyWithValue("retryRoutingKey", "first.custom.retry")
         .hasFieldOrPropertyWithValue("failedRoutingKey", "first.custom.failed");
   }
-
-  @Test
-  void testToString() {
-    String yaml = properties.toString();
-    System.out.println(yaml);
-    assertThat(yaml).isEqualTo("");
-  }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/config/properties/StringRepresentationTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/config/properties/StringRepresentationTest.java
@@ -2,8 +2,6 @@ package com.github.dbmdz.flusswerk.framework.config.properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
-import java.util.Map;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,85 +17,16 @@ class StringRepresentationTest {
   @DisplayName("should contain the class name")
   @Test
   void shouldContainClassName() {
-    String stringRepresentation = StringRepresentation.of(FlusswerkProperties.class).toString();
-    assertThat(stringRepresentation).startsWith("FlusswerkProperties");
+    ProcessingProperties properties = new ProcessingProperties(123);
+    String actual = StringRepresentation.of(properties);
+    assertThat(actual).contains("ProcessingProperties");
   }
 
-  @DisplayName("should intend properties")
+  @DisplayName("should contain property")
   @Test
-  void propertiesAreIntended() {
-    String stringRepresentation =
-        StringRepresentation.of(FlusswerkProperties.class)
-            .property("host", "example.com")
-            .property("username", "guest")
-            .toString();
-
-    assertThat(titleOf(stringRepresentation)).doesNotStartWith(INDENTATION);
-    assertThat(linesWithPropertiesOf(stringRepresentation)).are(STARTING_WITH_INDENTATION);
-  }
-
-  @DisplayName("should intend multiline properties")
-  @Test
-  void multilinePropertiesAreIntended() {
-    String stringRepresentation =
-        StringRepresentation.of(FlusswerkProperties.class)
-            .property("host", "example.com")
-            .property("description", "abc\ndef")
-            .toString();
-
-    assertThat(titleOf(stringRepresentation)).doesNotStartWith(INDENTATION);
-    assertThat(linesWithPropertiesOf(stringRepresentation)).are(STARTING_WITH_INDENTATION);
-  }
-
-  @DisplayName("should mask masked properties")
-  @Test
-  void maskedPropertiesAreMasked() {
-    String stringRepresentation =
-        StringRepresentation.of(FlusswerkProperties.class)
-            .maskedProperty("secret", "very_secret")
-            .toString();
-
-    assertThat(getPropertyValue("secret", stringRepresentation)).isEqualTo("v*****");
-  }
-
-  @DisplayName("should display lists")
-  @Test
-  void shouldDisplayLists() {
-    var expected = "FlusswerkProperties\n" + "\titems:\n" + "\t\t- a\n" + "\t\t- b\n";
-    var actual =
-        StringRepresentation.of(FlusswerkProperties.class)
-            .property("items", List.of("a", "b"))
-            .toString();
-    assertThat(actual).isEqualTo(expected);
-  }
-
-  @DisplayName("should display maps")
-  @Test
-  void shouldDisplayMaps() {
-    var expected = "FlusswerkProperties\n" + "\titems:\n" + "\t\ta:\tA\n" + "\t\tb:\tB\n";
-    var actual =
-        StringRepresentation.of(FlusswerkProperties.class)
-            .property("items", Map.of("a", "A", "b", "B"))
-            .toString();
-    assertThat(actual).isEqualTo(expected);
-  }
-
-  private String titleOf(String text) {
-    return text.split("\n")[0];
-  }
-
-  private List<String> linesWithPropertiesOf(String text) {
-    var lines = List.of(text.split("\n"));
-    return lines.subList(1, lines.size());
-  }
-
-  private String getPropertyValue(String property, String stringRepresentation) {
-    for (String line : linesWithPropertiesOf(stringRepresentation)) {
-      String[] kv = line.strip().split(":");
-      if (property.equals(kv[0])) {
-        return kv[1].strip();
-      }
-    }
-    return null;
+  void shouldContainProperty() {
+    ProcessingProperties properties = new ProcessingProperties(123);
+    String actual = StringRepresentation.of(properties);
+    assertThat(actual).contains("threads: 123");
   }
 }


### PR DESCRIPTION
This changes the String representation of all Flusswerk configuration property beans to YAML to remove a lot of complicated logic.

This does not introduce new dependencies because SnakeYAML is already a dependency of Spring Boot.