### PR TITLE
Add duration in seconds to logging

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Worker.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Worker.java
@@ -89,7 +89,7 @@ public class Worker implements Runnable {
     } finally {
       long stop = System.nanoTime();
       double duration = (stop - start) / 1e9;
-      MDC.put("duration", Double.toString(duration));
+      MDC.put("duration_s", Double.toString(duration));
     }
 
     // Data processing was successful, now handle the messaging

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Worker.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Worker.java
@@ -88,8 +88,8 @@ public class Worker implements Runnable {
       return; // processing was not successful → stop here
     } finally {
       long stop = System.nanoTime();
-      double duration = (stop - start) / 1e9;
-      MDC.put("duration_s", Double.toString(duration));
+      double duration = (stop - start) / 1e6;
+      MDC.put("duration_ms", Double.toString(duration));
     }
 
     // Data processing was successful, now handle the messaging

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Worker.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Worker.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 public class Worker implements Runnable {
 
@@ -76,6 +77,7 @@ public class Worker implements Runnable {
 
   public void process(Message message) {
     Collection<? extends Message> messagesToSend;
+    long start = System.nanoTime();
     try {
       messagesToSend = flow.process(message);
     } catch (StopProcessingException e) {
@@ -84,6 +86,10 @@ public class Worker implements Runnable {
     } catch (RuntimeException e) {
       retryOrFail(message, e);
       return; // processing was not successful → stop here
+    } finally {
+      long stop = System.nanoTime();
+      double duration = (stop - start) / 1e9;
+      MDC.put("duration", Double.toString(duration));
     }
 
     // Data processing was successful, now handle the messaging


### PR DESCRIPTION
The processing time for one item can be interesting for performance optimizations. 