### PR TITLE
Set CI Java versions to 11 and 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 16]
+        java: [11, 17]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK


### PR DESCRIPTION
Change CI java version to use the two latest LTS versions (that also is the former LTS and the latest Java version).