### PR TITLE
Envelope: Replace LocalDateTime with Instant

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Envelope.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/model/Envelope.java
@@ -1,6 +1,6 @@
 package com.github.dbmdz.flusswerk.framework.model;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 /** Technical metadata all implementations of {@link Message} must have. */
 public class Envelope {
@@ -11,13 +11,13 @@ public class Envelope {
 
   private int retries;
 
-  private LocalDateTime timestamp;
+  private Instant created;
 
   private String source;
 
   /** Default constructor setting the Envelope.timestamp to now. */
   public Envelope() {
-    timestamp = LocalDateTime.now();
+    created = Instant.now();
   }
 
   /**
@@ -81,18 +81,17 @@ public class Envelope {
    *
    * @return The timestamp when the message was created.
    */
-  @Deprecated
-  public LocalDateTime getTimestamp() {
-    return timestamp;
+  public Instant getCreated() {
+    return created;
   }
 
   /**
    * Sets the timestamp when the {@link Message} was created.
    *
-   * @param timestamp The timestamp when the message was created.
+   * @param created The timestamp when the message was created.
    */
-  public void setTimestamp(LocalDateTime timestamp) {
-    this.timestamp = timestamp;
+  public void setCreated(Instant created) {
+    this.created = created;
   }
 
   /**

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClientTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClientTest.java
@@ -21,7 +21,7 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.GetResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -84,10 +84,10 @@ class RabbitClientTest {
     long deliveryTag = 476253;
     String tracingId = "123123123";
     int retries = 333;
-    LocalDateTime timestamp = LocalDateTime.now();
+    Instant created = Instant.now();
     String inputQueue = "some.input.queue";
 
-    Message messageToReceive = createMessage(retries, timestamp);
+    Message messageToReceive = createMessage(retries, created);
     GetResponse response = createResponse(deliveryTag, messageToReceive, rabbitClient);
 
     String body = new String(response.getBody(), StandardCharsets.UTF_8);
@@ -98,13 +98,13 @@ class RabbitClientTest {
         .returns(body, from(Envelope::getBody))
         .returns(deliveryTag, from(Envelope::getDeliveryTag))
         .returns(retries, from(Envelope::getRetries))
-        .returns(timestamp, from(Envelope::getTimestamp));
+        .returns(created, from(Envelope::getCreated));
   }
 
-  private Message createMessage(int retries, LocalDateTime timestamp) {
+  private Message createMessage(int retries, Instant created) {
     Message messageToReceive = new Message();
     messageToReceive.getEnvelope().setRetries(retries);
-    messageToReceive.getEnvelope().setTimestamp(timestamp);
+    messageToReceive.getEnvelope().setCreated(created);
     return messageToReceive;
   }
 


### PR DESCRIPTION
Replace the timestamp for when the message was created with a locale independent type that represents a Moment.