### PR TITLE
Release 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Java application).
 <dependency>
   <groupId>com.github.dbmdz.flusswerk</groupId>
   <artifactId>framework</artifactId>
-  <version>4.1.0</version>
+  <version>5.0.0</version>
 </dependency>
 ```
 
@@ -23,7 +23,7 @@ Java application).
 
 ```groovy
 dependencies {
-    compile group: 'com.github.dbmdz.flusswerk', name: 'flusswerk', version: '4.1.0'
+    compile group: 'com.github.dbmdz.flusswerk', name: 'flusswerk', version: '5.0.0'
 }
 ``` 
  
@@ -33,15 +33,14 @@ To get started, clone or copy the [Flusswerk
 Example](https://github.com/dbmdz/flusswerk-example) application.
 
  
-## Migration to version 4
+## What's new in Flusswerk 5
 
-Starting with Flusswerk 4, there are two major changes:
-
- - Any Flusswerk application uses now Spring Boot and needs beans for
-    [FlowSpec][FlowSpec] (defining the processing) and
-    [IncomingMessageType][IncomingMessageType].
- - The package names changed from `de.digitalcollections.flusswerk.engine` to
-   `com.github.dbmdz.framework`.
+- Flusswerk connections are now shown in RabbitMQ management UI
+- structured logging now automatically contains fields `duration` and `duration_ms` that report the time your app spent on processing a certain message in seconds or milliseconds.
+- The deprecated `tracing_id` has been removed
+- The deprecated `Envelope.timestamp` has been removed in favor of `Envelope.created` which is now of type `Instant`.
+- Constructor of FlusswerkApplication now takes `Optional<Engine>` as an argument (call as `super(Optional.of(engine));`).
+- Options for centralized locking using Redis have been removed
 
 [FlowSpec]:
 framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/FlowSpec.java

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
@@ -61,8 +61,9 @@ public class Flow {
     } finally {
       info.stop();
       long stop = System.nanoTime();
-      double duration = (stop - start) / 1e6;
-      MDC.put("duration_ms", Double.toString(duration));
+      double duration = (stop - start) / 1e3;
+      MDC.put("duration", Double.toString(duration));
+      MDC.put("duration_ms", Double.toString(duration / 1e3));
       flowMetrics.forEach(
           metric -> metric.accept(info)); // record metrics only available from inside the framework
     }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.dbmdz.flusswerk</groupId>
   <artifactId>flusswerk</artifactId>
-  <version>5.0.0-SNAPSHOT</version>
+  <version>5.0.0</version>
   <packaging>pom</packaging>
 
   <name>Flusswerk</name>
@@ -71,7 +71,7 @@
     <!-- Dependency versions -->
     <version.amqp-client>5.13.1</version.amqp-client>
     <version.logstash-encoder>6.6</version.logstash-encoder>
-    <version.flusswerk>5.0.0-SNAPSHOT</version.flusswerk>
+    <version.flusswerk>5.0.0</version.flusswerk>
     <version.junit>5.7.0</version.junit>
     <version.mockito>4.0.0</version.mockito>
     <!-- Plugin versions -->


### PR DESCRIPTION
- Flusswerk connections are now shown in RabbitMQ management UI
- structured logging now automatically contains fields `duration` and `duration_ms` that report the time your app spent on processing a certain message in seconds or milliseconds.
- The deprecated `tracing_id` has been removed
- The deprecated `Envelope.timestamp` has been removed in favor of `Envelope.created` which is now of type `Instant`.
- Constructor of FlusswerkApplication now takes `Optional<Engine>` as an argument (call as `super(Optional.of(engine));`).
- Options for centralized locking using Redis have been removed
