### PR TITLE
Release availableWorkers semaphore when message deserialization fails.

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/FlusswerkConsumer.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/FlusswerkConsumer.java
@@ -75,6 +75,7 @@ public class FlusswerkConsumer extends DefaultConsumer {
     } catch (Exception e) {
       LOGGER.error("Could not deserialize message", e);
       channel.basicAck(envelope.getDeliveryTag(), false);
+      availableWorkers.release();
     }
   }
 


### PR DESCRIPTION
Previously every message that failed to deserialize would decrease the
number of available workers by one. This led to a sitaution, where after
a few messages (as many as there are available workers configured) the
engine would just refuse to accept any incoming messages, since it would
wait for eternity for the `availableWorkers` to become available again.