### PR TITLE
Fix logging when deserialize fails

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/jackson/FlusswerkObjectMapper.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/jackson/FlusswerkObjectMapper.java
@@ -25,4 +25,14 @@ public class FlusswerkObjectMapper extends ObjectMapper {
   public Message deserialize(String json) throws JsonProcessingException {
     return readValue(json, messageClass);
   }
+
+  /**
+   * Convenience factory method to prevent overly long lines.
+   *
+   * @param type The class for incoming messages
+   * @return a new instance of FlusswerkObjectMapper.
+   */
+  public static FlusswerkObjectMapper forIncoming(Class<? extends Message> type) {
+    return new FlusswerkObjectMapper(new IncomingMessageType(type));
+  }
 }


### PR DESCRIPTION
When deserializing fails (e.g. because a Message implementation validates input in the constructor), then the log message containing the errror should also contain the tracing information whenever possible.