### PR TITLE
Refactor consumer semphore handling for single responsibility

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -132,14 +132,8 @@ public class FlusswerkConfiguration {
   }
 
   @Bean
-  public Semaphore availableWorkers(ProcessingProperties processingProperties) {
-    return new Semaphore(processingProperties.getThreads());
-  }
-
-  @Bean
   public List<Worker> workers(
       AppProperties appProperties,
-      Semaphore availableWorkers,
       Optional<Flow> flow,
       MessageBroker messageBroker,
       ProcessingProperties processingProperties,
@@ -153,7 +147,6 @@ public class FlusswerkConfiguration {
         .mapToObj(
             n ->
                 new Worker(
-                    availableWorkers,
                     flow.get(),
                     messageBroker,
                     processReport.orElseGet(
@@ -165,7 +158,6 @@ public class FlusswerkConfiguration {
 
   @Bean
   public List<FlusswerkConsumer> flusswerkConsumers(
-      Semaphore availableWorkers,
       FlusswerkObjectMapper flusswerkObjectMapper,
       ProcessingProperties processingProperties,
       RabbitConnection rabbitConnection,
@@ -173,6 +165,8 @@ public class FlusswerkConfiguration {
       PriorityBlockingQueue<Task> taskQueue) {
     int maxPriority = routingProperties.getIncoming().size();
     List<FlusswerkConsumer> flusswerkConsumers = new ArrayList<>();
+
+    Semaphore availableWorkers = new Semaphore(processingProperties.getThreads());
     for (int i = 0; i < routingProperties.getIncoming().size(); i++) {
       String queueName = routingProperties.getIncoming().get(i);
       int priority = maxPriority - i;

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/FlusswerkConsumer.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/FlusswerkConsumer.java
@@ -77,7 +77,7 @@ public class FlusswerkConsumer extends DefaultConsumer {
       Message message = flusswerkObjectMapper.deserialize(json);
       message.getEnvelope().setSource(inputQueue);
       message.getEnvelope().setDeliveryTag(envelope.getDeliveryTag());
-      taskQueue.put(new Task(message, priority));
+      taskQueue.put(new Task(message, priority, availableWorkers::release));
     } catch (Exception e) {
       List<String> tracing = null;
       try {

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Task.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Task.java
@@ -7,21 +7,37 @@ import java.util.Objects;
 
 public class Task implements Comparable<Task> {
 
+  private static final Runnable DO_NOTHING = () -> {};
+
   private final Message message;
   private final int priority;
+  private final Runnable callback;
 
-  public Task(Message message, int priority) {
+  public Task(Message message, int priority, Runnable callback) {
     this.message = requireNonNull(message);
     this.priority = priority;
+    this.callback = Objects.requireNonNullElse(callback, DO_NOTHING);
+  }
+
+  public Task(Message message, int priority) {
+    this(message, priority, DO_NOTHING);
   }
 
   public Message getMessage() {
     return message;
   }
 
+  public int getPriority() {
+    return priority;
+  }
+
   @Override
   public int compareTo(Task other) {
     return other.priority - this.priority;
+  }
+
+  public void done() {
+    this.callback.run();
   }
 
   @Override
@@ -33,16 +49,25 @@ public class Task implements Comparable<Task> {
       return false;
     }
     Task task = (Task) o;
-    return priority == task.priority && Objects.equals(message, task.message);
+    return priority == task.priority
+        && Objects.equals(message, task.message)
+        && Objects.equals(callback, task.callback);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(message, priority);
+    return Objects.hash(message, priority, callback);
   }
 
   @Override
   public String toString() {
-    return "Task{" + "message=" + message + ", priority=" + priority + '}';
+    return "Task{"
+        + "message="
+        + message
+        + ", priority="
+        + priority
+        + ", callback="
+        + callback
+        + '}';
   }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/engine/FlusswerkConsumerTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/engine/FlusswerkConsumerTest.java
@@ -55,11 +55,15 @@ class FlusswerkConsumerTest {
   @Test
   void handleDelivery() throws IOException {
     TestMessage message = new TestMessage("bsb12345678");
-    Task expected = new Task(message, 42);
+    int priority = 42;
 
     consumer.handleDelivery("consumerTag", envelope, basicProperties, json(message));
     assertThat(taskQueue).hasSize(1);
-    assertThat(taskQueue.poll()).isEqualTo(expected);
+    Task actual = taskQueue.poll();
+    assertThat(actual).isNotNull(); // to prevent NPE warning
+    // task.callback breaks actual.equals(expected) here, so we need to compare fields directly
+    assertThat(actual.getMessage()).isEqualTo(message);
+    assertThat(actual.getPriority()).isEqualTo(priority);
   }
 
   @DisplayName("should return input queue")


### PR DESCRIPTION
There should be only one class responsible for managing the consumer semaphore.

There are two possible scenarios when the processing is done and the semaphore should be freed:
 - on the consumer end: when the processing is done (successful or with error)
 - on the producer end: when there was an error that prevents processing from even starting (deserializing message fails)

To ensure single responsibility and minimize the risk of double-freeing or not-freeing the semaphore at all, the class responsible for acquiring the semaphore should also be responsible for freeing (FlusswerkConsumer). The other case (Worker) will be handled with a callback set by FlusswerkConsumer.