### PR TITLE
Fix duration logging

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
@@ -61,9 +61,9 @@ public class Flow {
     } finally {
       info.stop();
       long stop = System.nanoTime();
-      double duration = (stop - start) / 1e3;
-      MDC.put("duration", Double.toString(duration));
-      MDC.put("duration_ms", Double.toString(duration / 1e3));
+      double durationMs = (stop - start) / 1e3;
+      MDC.put("duration", Double.toString(durationMs / 1e3));
+      MDC.put("duration_ms", Double.toString(durationMs));
       flowMetrics.forEach(
           metric -> metric.accept(info)); // record metrics only available from inside the framework
     }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -62,8 +63,8 @@ public class Flow {
       info.stop();
       long stop = System.nanoTime();
       double durationMs = (stop - start) / 1e3;
-      MDC.put("duration", Double.toString(durationMs / 1e3));
-      MDC.put("duration_ms", Double.toString(durationMs));
+      MDC.put("duration", String.format(Locale.ENGLISH, "%f", durationMs / 1e3));
+      MDC.put("duration_ms", String.format(Locale.ENGLISH, "%f", durationMs));
       flowMetrics.forEach(
           metric -> metric.accept(info)); // record metrics only available from inside the framework
     }


### PR DESCRIPTION
The log values for `duration` and `duration_ms` where switched. Number format is changed to avoid exponential notation, so log parsers do not have to support this.