### PR TITLE
Fix prometheus labels

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>5.0.3</version>
+    <version>5.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -86,11 +86,8 @@ public class FlusswerkConfiguration {
 
   @Bean
   public MeterFactory meterFactory(
-      AppProperties appProperties,
-      MonitoringProperties monitoringProperties,
-      MeterRegistry meterRegistry) {
-    return new MeterFactory(
-        monitoringProperties.getPrefix(), appProperties.getName(), meterRegistry);
+      MonitoringProperties monitoringProperties, MeterRegistry meterRegistry) {
+    return new MeterFactory(monitoringProperties.getPrefix(), meterRegistry);
   }
 
   @Bean

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/MeterFactory.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/MeterFactory.java
@@ -1,39 +1,34 @@
 package com.github.dbmdz.flusswerk.framework.monitoring;
 
+import static java.util.Arrays.asList;
+
 import com.github.dbmdz.flusswerk.framework.flow.FlowInfo.Status;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /** Convenience factory to simplify the creation of {@link Counter} meters. */
 public class MeterFactory {
   private final String basename;
-  private final String app;
   private final MeterRegistry registry;
 
   /**
    * @param basename The prefix for the created metrics ("e.g. flusswerk for flusswerk.items.total")
-   * @param app The app name to add as a tag to all metrics
    * @param registry the Micrometer registry to create the counters
    */
-  public MeterFactory(String basename, String app, MeterRegistry registry) {
+  public MeterFactory(String basename, MeterRegistry registry) {
     this.basename = basename;
-    this.app = app;
     this.registry = registry;
   }
 
   public Counter counter(String metric, String... tags) {
     var completeName = basename + "." + metric;
-    List<String> allTags = new ArrayList<>();
-    allTags.addAll(List.of("job", app));
-    allTags.addAll(Arrays.asList(tags));
-    return registry.counter(completeName, allTags.toArray(new String[] {}));
+    return registry.counter(completeName, tags);
   }
 
   public Counter counter(String metric, Status status, String... tags) {
-    List<String> allTags = new ArrayList<>(Arrays.asList(tags));
+    List<String> allTags = new ArrayList<>(asList(tags));
     allTags.add("status");
     allTags.add(status.toString().toLowerCase());
     return counter(metric, allTags.toArray(new String[] {}));

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/monitoring/MeterFactoryTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/monitoring/MeterFactoryTest.java
@@ -15,7 +15,7 @@ class MeterFactoryTest {
     var monitoringMetric = "test.metric";
 
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-    MeterFactory meterFactory = new MeterFactory(monitoringPrefix, "test_app", meterRegistry);
+    MeterFactory meterFactory = new MeterFactory(monitoringPrefix, meterRegistry);
 
     Counter counter = meterFactory.counter(monitoringMetric);
     Search search = meterRegistry.find(monitoringPrefix + "." + monitoringMetric);

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>5.0.3</version>
+    <version>5.0.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.dbmdz.flusswerk</groupId>
   <artifactId>flusswerk</artifactId>
-  <version>5.0.3</version>
+  <version>5.0.4-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Flusswerk</name>
@@ -71,7 +71,7 @@
     <!-- Dependency versions -->
     <version.amqp-client>5.14.0</version.amqp-client>
     <version.logstash-encoder>6.6</version.logstash-encoder>
-    <version.flusswerk>5.0.3</version.flusswerk>
+    <version.flusswerk>5.0.4-SNAPSHOT</version.flusswerk>
     <version.junit>5.7.0</version.junit>
     <version.mockito>4.3.1</version.mockito>
     <!-- Plugin versions -->


### PR DESCRIPTION
The `job` label in Prometheus should be handled by the static Prometheus configuration or the Prometheus service discovery.