### PR TITLE
Fix the installation of libxml2-utils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
       - name: Install XML utils
-        run: sudo apt install libxml2-utils
+        run: sudo apt update && sudo apt install libxml2-utils
       - name: Set project version
         run: echo "PROJECT_VERSION=$(xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]/text()' pom.xml)" >> $GITHUB_ENV
       # Publish snapshot


### PR DESCRIPTION
This PR fixes the installation of `libxml2-utils` in GitHub Actions

[_Created by Sourcegraph batch change `admin/fix-libxml2-utils-installation`._](http://sourcegraph.ti2.digitale-sammlungen.de/users/admin/batch-changes/fix-libxml2-utils-installation)