### PR TITLE
Fix missing tracing information for exceptions

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/Flow.java
@@ -67,6 +67,12 @@ public class Flow {
       flowMetrics.forEach(
           metric -> metric.accept(info)); // record metrics only available from inside the framework
     }
+
+    result.stream()
+        .filter(Objects::nonNull)
+        .filter(m -> m.getTracing() == null || m.getTracing().isEmpty())
+        .forEach(m -> m.setTracing(tracing.tracingPath()));
+
     return result;
   }
 
@@ -91,11 +97,6 @@ public class Flow {
     if (result == null) {
       return Collections.emptyList();
     }
-
-    result.stream()
-        .filter(Objects::nonNull)
-        .filter(m -> m.getTracing() == null || m.getTracing().isEmpty())
-        .forEach(m -> m.setTracing(tracing.tracingPath()));
 
     return result;
   }


### PR DESCRIPTION
Tracing-IDs got lost when a SkipProcessingException was thrown. This PR moves propagation of tracing IDs to the correct place.