### PR TITLE
Introduce proper framework metrics

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -15,6 +15,7 @@ import com.github.dbmdz.flusswerk.framework.jackson.FlusswerkObjectMapper;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.monitoring.DefaultFlowMetrics;
 import com.github.dbmdz.flusswerk.framework.monitoring.FlowMetrics;
+import com.github.dbmdz.flusswerk.framework.monitoring.FlusswerkMetrics;
 import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitClient;
@@ -136,7 +137,8 @@ public class FlusswerkConfiguration {
       ProcessingProperties processingProperties,
       Optional<ProcessReport> processReport,
       PriorityBlockingQueue<Task> taskQueue,
-      Tracing tracing) {
+      Tracing tracing,
+      FlusswerkMetrics metrics) {
     if (flow.isEmpty()) {
       return Collections.emptyList(); // No Flow, nothing to do
     }
@@ -145,12 +147,19 @@ public class FlusswerkConfiguration {
             n ->
                 new Worker(
                     flow.get(),
+                    metrics,
                     messageBroker,
                     processReport.orElseGet(
                         () -> new DefaultProcessReport(appProperties.getName())),
                     taskQueue,
                     tracing))
         .collect(Collectors.toList());
+  }
+
+  @Bean
+  public FlusswerkMetrics metrics(
+      ProcessingProperties processingProperties, MeterRegistry meterRegistry) {
+    return new FlusswerkMetrics(processingProperties, meterRegistry);
   }
 
   @Bean

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/DefaultFlowMetrics.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/DefaultFlowMetrics.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public class DefaultFlowMetrics implements FlowMetrics {
 
   protected final Map<Status, Counter> messagesTotal;
-  protected final Map<Status, Counter> processingSeconds;
+  protected final Map<Status, Counter> messagesSeconds;
 
   @Deprecated(since = "5.1.0", forRemoval = true)
   private final Map<Status, Counter> executionTime;
@@ -22,7 +22,7 @@ public class DefaultFlowMetrics implements FlowMetrics {
 
   public DefaultFlowMetrics(MeterFactory meterFactory) {
     messagesTotal = new EnumMap<>(Status.class);
-    processingSeconds = new EnumMap<>(Status.class);
+    messagesSeconds = new EnumMap<>(Status.class);
     this.executionTime = new EnumMap<>(Status.class);
     this.processedItems = new EnumMap<>(Status.class);
 
@@ -30,7 +30,7 @@ public class DefaultFlowMetrics implements FlowMetrics {
       processedItems.put(status, meterFactory.counter("processed.items", status));
       executionTime.put(status, meterFactory.counter("execution.time", status));
       messagesTotal.put(status, meterFactory.frameworkCounter("messages.total", status));
-      processingSeconds.put(status, meterFactory.frameworkCounter("processing.seconds", status));
+      messagesSeconds.put(status, meterFactory.frameworkCounter("messages.seconds", status));
     }
   }
 
@@ -39,6 +39,6 @@ public class DefaultFlowMetrics implements FlowMetrics {
     processedItems.get(status).increment();
     executionTime.get(status).increment(flowInfo.duration());
     messagesTotal.get(status).increment();
-    processingSeconds.get(status).increment(flowInfo.duration());
+    messagesSeconds.get(status).increment(flowInfo.duration());
   }
 }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/DefaultFlowMetrics.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/DefaultFlowMetrics.java
@@ -11,16 +11,26 @@ import java.util.Map;
  */
 public class DefaultFlowMetrics implements FlowMetrics {
 
+  protected final Map<Status, Counter> messagesTotal;
+  protected final Map<Status, Counter> processingSeconds;
+
+  @Deprecated(since = "5.1.0", forRemoval = true)
   private final Map<Status, Counter> executionTime;
+
+  @Deprecated(since = "5.1.0", forRemoval = true)
   private final Map<Status, Counter> processedItems;
 
   public DefaultFlowMetrics(MeterFactory meterFactory) {
+    messagesTotal = new EnumMap<>(Status.class);
+    processingSeconds = new EnumMap<>(Status.class);
     this.executionTime = new EnumMap<>(Status.class);
     this.processedItems = new EnumMap<>(Status.class);
 
     for (Status status : Status.values()) {
       processedItems.put(status, meterFactory.counter("processed.items", status));
       executionTime.put(status, meterFactory.counter("execution.time", status));
+      messagesTotal.put(status, meterFactory.frameworkCounter("messages.total", status));
+      processingSeconds.put(status, meterFactory.frameworkCounter("processing.seconds", status));
     }
   }
 
@@ -28,5 +38,7 @@ public class DefaultFlowMetrics implements FlowMetrics {
     var status = flowInfo.getStatus();
     processedItems.get(status).increment();
     executionTime.get(status).increment(flowInfo.duration());
+    messagesTotal.get(status).increment();
+    processingSeconds.get(status).increment(flowInfo.duration());
   }
 }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/FlusswerkMetrics.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/FlusswerkMetrics.java
@@ -1,0 +1,36 @@
+package com.github.dbmdz.flusswerk.framework.monitoring;
+
+import com.github.dbmdz.flusswerk.framework.config.properties.ProcessingProperties;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class FlusswerkMetrics {
+
+  private final AtomicInteger activeWorkers = new AtomicInteger(0);
+
+  private final int totalWorkers;
+
+  public FlusswerkMetrics(ProcessingProperties properties, MeterRegistry registry) {
+    this.totalWorkers = properties.getThreads();
+
+    Gauge.builder("flusswerk.workers.total", activeWorkers, AtomicInteger::get)
+        .description("Number of worker threads in the system")
+        .tags(Tags.of("state", "active"))
+        .register(registry);
+
+    Gauge.builder("flusswerk.workers.total", activeWorkers, w -> totalWorkers - w.get())
+        .description("Number of worker threads in the system")
+        .tags(Tags.of("state", "idle"))
+        .register(registry);
+  }
+
+  public void incrementActiveWorkers() {
+    activeWorkers.incrementAndGet();
+  }
+
+  public void decrementActiveWorkers() {
+    activeWorkers.decrementAndGet();
+  }
+}

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/MeterFactory.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/MeterFactory.java
@@ -32,4 +32,8 @@ public class MeterFactory {
     allTags.add(status.toString().toLowerCase());
     return counter(metric, allTags.toArray(new String[] {}));
   }
+
+  public Counter frameworkCounter(String name, Status status) {
+    return registry.counter("flusswerk." + name, "status", status.toString().toLowerCase());
+  }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/monitoring/DefaultFlowMetricsTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/monitoring/DefaultFlowMetricsTest.java
@@ -3,6 +3,7 @@ package com.github.dbmdz.flusswerk.framework.monitoring;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,12 +41,13 @@ class DefaultFlowMetricsTest {
     MeterFactory meterFactory = mock(MeterFactory.class);
     Counter counter = mock(Counter.class);
     when(meterFactory.counter(any(), eq(Status.SUCCESS))).thenReturn(counter);
+    when(meterFactory.frameworkCounter(any(), eq(Status.SUCCESS))).thenReturn(counter);
     DefaultFlowMetrics defaultFlowMetrics = new DefaultFlowMetrics(meterFactory);
 
     FlowInfo flowInfo = mock(FlowInfo.class);
     when(flowInfo.getStatus()).thenReturn(Status.SUCCESS);
     defaultFlowMetrics.accept(flowInfo);
-    verify(flowInfo).duration();
+    verify(flowInfo, times(2)).duration();
     verify(flowInfo).getStatus();
   }
 }


### PR DESCRIPTION
So far, Flusswerk defines two metrics out-of-the-box: total amount processed messages, and total time spent processing the message.

There are two issues with the current implementation:

1. the names are not following Prometheus best practices
2. framework metrics and user defined metrics share the same prefix as configured with `flusswerk.monitoring.basename` (default: "flusswerk")

This PR introduces two new metrics that are named independently from the value of basename and that follow best practices:

`flusswerk_messages_total` is the total number of messages processed since start of the application, `flusswerk_processing_seconds` the time spent on processing. Values from parallel threads are added up.
