### PR TITLE
Bump version to 5.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,27 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [5.1.0] - 2022-05-18
+### Added
+
+- Message processing can now be skipped by throwing a SkipProcessingException. Log messages now have a field `status` to indicate this. ([#355](https://github.com/dbmdz/flusswerk/pull/355))
+- New framework metrics `flusswerk_messages_total` and `flusswerk_messages_seconds` (Counter). The prefix is independent from the application prefix since the metric is the same for all Flusswerk-based applications. ([#381](https://github.com/dbmdz/flusswerk/pull/381)).
+- New framework metrics `flusswerk_workers` (Gauge). The prefix is independent from the application prefix since the metric is the same for all Flusswerk-based applications. ([#381](https://github.com/dbmdz/flusswerk/pull/381)).
+- Flusswerk applications now can send raw messages: `Topic.sendRaw(byte[] message)` ([#381](https://github.com/dbmdz/flusswerk/pull/381)).
+
+### Changed
+
+- Autoformatting now uses com.spotify:fmt-maven-plugin and works with JDK17.
+
+### Deprecated
+
+- The framework metrics `flusswerk_processed_times` and `flusswerk_execution_time` have been deprecated since they don't follow Prometheus best practices.
+- The logging field `duration_ms` is deprecated since a corresponding field `duration` exists and will be removed in the future. Logging and metrics will strictly use SI base units where possible.
+
+### Fixed
+
+- Tracing information got lost when the application threw certain exceptions ([#380](https://github.com/dbmdz/flusswerk/pull/380)).
+- The logged values of `duration` and `duration_ms` where switched ([#345](https://github.com/dbmdz/flusswerk/pull/345)).

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>5.1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>5.1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.dbmdz.flusswerk</groupId>
   <artifactId>flusswerk</artifactId>
-  <version>5.1.0-SNAPSHOT</version>
+  <version>5.1.0</version>
   <packaging>pom</packaging>
 
   <name>Flusswerk</name>
@@ -72,7 +72,7 @@
     <version.amqp-client>5.14.2</version.amqp-client>
     <version.byte-buddy>1.12.10</version.byte-buddy>
     <version.logstash-encoder>7.1.1</version.logstash-encoder>
-    <version.flusswerk>5.1.0-SNAPSHOT</version.flusswerk>
+    <version.flusswerk>5.1.0</version.flusswerk>
     <version.junit>5.7.0</version.junit>
     <version.mockito>4.5.1</version.mockito>
     <!-- Plugin versions -->
@@ -83,6 +83,7 @@
     <version.nexus-staging-maven-plugin>1.6.13</version.nexus-staging-maven-plugin>
     <version.wagon-maven-plugin>2.0.2</version.wagon-maven-plugin>
     <version.huxhorn-sulky-ulid>8.3.0</version.huxhorn-sulky-ulid>
+    <version.junit-jupiter>5.8.2</version.junit-jupiter>
   </properties>
 
   <dependencyManagement>
@@ -117,7 +118,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
-        <version>5.8.2</version>
+        <version>${version.junit-jupiter}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### Added

- Message processing can now be skipped by throwing a SkipProcessingException. Log messages now have a field `status` to indicate this. ([#355](https://github.com/dbmdz/flusswerk/pull/355))
- New framework metrics `flusswerk_messages_total` and `flusswerk_messages_seconds` (Counter). The prefix is independent from the application prefix since the metric is the same for all Flusswerk-based applications. ([#381](https://github.com/dbmdz/flusswerk/pull/381)).
- New framework metrics `flusswerk_workers` (Gauge). The prefix is independent from the application prefix since the metric is the same for all Flusswerk-based applications. ([#381](https://github.com/dbmdz/flusswerk/pull/381)).
- Flusswerk applications now can send raw messages: `Topic.sendRaw(byte[] message)` ([#381](https://github.com/dbmdz/flusswerk/pull/381)).

### Changed

- Autoformatting now uses com.spotify:fmt-maven-plugin and works with JDK17.

### Deprecated

- The framework metrics `flusswerk_processed_times` and `flusswerk_execution_time` have been deprecated since they don't follow Prometheus best practices.
- The logging field `duration_ms` is deprecated since a corresponding field `duration` exists and will be removed in the future. Logging and metrics will strictly use SI base units where possible.

### Fixed

- Tracing information got lost when the application threw certain exceptions ([#380](https://github.com/dbmdz/flusswerk/pull/380)).
- The logged values of `duration` and `duration_ms` where switched ([#345](https://github.com/dbmdz/flusswerk/pull/345)).