### PR TITLE
Rely on automatic connection recovery instead of manually managing it.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,7 @@ jobs:
       --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
       --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
       --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED "
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [11, 17]
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -25,7 +22,7 @@ jobs:
         with:
           check-latest: true
           distribution: temurin
-          java-version: ${{ matrix.java }}
+          java-version: 17
       - uses: actions/cache@v2
         env:
           cache-name: cache-maven-artifacts
@@ -34,15 +31,6 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
       - name: Build with Maven
         run: mvn -B -Pintegration verify
-    services:
-      rabbitmq:
-        image: rabbitmq:3-alpine
-        ports:
-          - 5672:5672
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
   publish:
     if: (github.event_name == 'push' && contains(github.ref, 'main')) || github.event_name == 'release'
     runs-on: ubuntu-latest
@@ -60,13 +48,13 @@ jobs:
       - name: Set project version
         run: echo "PROJECT_VERSION=$(xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]/text()' pom.xml)" >> $GITHUB_ENV
       # Publish snapshot
-      - name: Set up JDK 11 for publishing a snapshot
+      - name: Set up JDK 17 for publishing a snapshot
         if: github.event_name == 'push' && endswith(env.PROJECT_VERSION, 'SNAPSHOT')
         uses: actions/setup-java@v2
         with:
           check-latest: true
           distribution: temurin
-          java-version: 11
+          java-version: 17
           server-id: ossrh-snapshots
           server-password: MAVEN_PASSWORD
           server-username: MAVEN_USERNAME
@@ -77,7 +65,7 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
       # Publish release
-      - name: Set up JDK 11 for publishing a release
+      - name: Set up JDK 17 for publishing a release
         if: github.event_name == 'release' && !endswith(env.PROJECT_VERSION, 'SNAPSHOT')
         uses: actions/setup-java@v2
         with:
@@ -85,7 +73,7 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           check-latest: true
           distribution: temurin
-          java-version: 11
+          java-version: 17
           server-id: ossrh
           server-password: MAVEN_PASSWORD
           server-username: MAVEN_USERNAME

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
       --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED "
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        java: [11, 17]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -22,7 +25,7 @@ jobs:
         with:
           check-latest: true
           distribution: temurin
-          java-version: 17
+          java-version: ${{ matrix.java }}
       - uses: actions/cache@v2
         env:
           cache-name: cache-maven-artifacts
@@ -31,9 +34,14 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
       - name: Build with Maven
         run: mvn -B -Pintegration verify
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
   publish:
     if: (github.event_name == 'push' && contains(github.ref, 'main')) || github.event_name == 'release'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@v2
@@ -48,13 +56,13 @@ jobs:
       - name: Set project version
         run: echo "PROJECT_VERSION=$(xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]/text()' pom.xml)" >> $GITHUB_ENV
       # Publish snapshot
-      - name: Set up JDK 17 for publishing a snapshot
+      - name: Set up JDK 11 for publishing a snapshot
         if: github.event_name == 'push' && endswith(env.PROJECT_VERSION, 'SNAPSHOT')
         uses: actions/setup-java@v2
         with:
           check-latest: true
           distribution: temurin
-          java-version: 17
+          java-version: 11
           server-id: ossrh-snapshots
           server-password: MAVEN_PASSWORD
           server-username: MAVEN_USERNAME
@@ -65,7 +73,7 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
       # Publish release
-      - name: Set up JDK 17 for publishing a release
+      - name: Set up JDK 11 for publishing a release
         if: github.event_name == 'release' && !endswith(env.PROJECT_VERSION, 'SNAPSHOT')
         uses: actions/setup-java@v2
         with:
@@ -73,7 +81,7 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           check-latest: true
           distribution: temurin
-          java-version: 17
+          java-version: 11
           server-id: ossrh
           server-password: MAVEN_PASSWORD
           server-username: MAVEN_USERNAME

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: mvn -B -Pintegration verify
   publish:
     if: (github.event_name == 'push' && contains(github.ref, 'main')) || github.event_name == 'release'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - uses: actions/checkout@v2

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -85,6 +85,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>17</source>
+          <target>17</target>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -85,10 +85,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>17</source>
-          <target>17</target>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/MessageBroker.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/MessageBroker.java
@@ -108,7 +108,21 @@ public class MessageBroker {
    * @throws InvalidMessageException if the message could not be read and deserialized
    */
   public Message receive(String queueName) throws IOException, InvalidMessageException {
-    return rabbitClient.receive(queueName);
+    return receive(queueName, false);
+  }
+
+  /**
+   * Gets one message from the queue. If specified, the message will be acknowledged automatically.
+   *
+   * @param queueName the queue to receive.
+   * @param autoAck whether the message should be acknowledged automatically.
+   * @return the received message.
+   * @throws IOException if communication with RabbitMQ failed.
+   * @throws InvalidMessageException if the message could not be read and deserialized
+   */
+  public Message receive(String queueName, boolean autoAck)
+      throws IOException, InvalidMessageException {
+    return rabbitClient.receive(queueName, autoAck);
   }
 
   /**

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/Queue.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/Queue.java
@@ -48,15 +48,16 @@ public class Queue {
   }
 
   /**
-   * Tries to receives a message from RabbitMQ.
+   * Tries to receive a message from RabbitMQ.
    *
+   * @param autoAck whether the message should be acknowledged automatically.
    * @return An {@link Optional} that contains the received message or is empty if the queue is
    *     empty.
    * @throws IOException If communication with RabbitMQ fails.
    * @throws InvalidMessageException If deserialization of the message fails.
    */
-  public Optional<Message> receive() throws IOException, InvalidMessageException {
-    Message message = rabbitClient.receive(name);
+  public Optional<Message> receive(boolean autoAck) throws IOException, InvalidMessageException {
+    Message message = rabbitClient.receive(name, autoAck);
     return Optional.ofNullable(message);
   }
 

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
@@ -107,7 +107,9 @@ public class RabbitClient {
           channel.basicPublish(exchange, routingKey, properties, data);
           break;
         } catch (IOException | AlreadyClosedException e) {
-          log.warn("Failed to publish message to RabbitMQ: {}", e.getMessage(), e);
+          log.warn(
+              "Failed to publish message to RabbitMQ: '{}', waiting for channel to become available again",
+              e.getMessage());
           channelAvailable = false;
         }
       }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
@@ -55,7 +55,8 @@ public class RabbitClient {
     channel = connection.getChannel();
     // We need a recoverable connection since we don't want to handle connection and channel
     // recovery ourselves.
-    if (channel instanceof RecoverableChannel rc) {
+    if (channel instanceof RecoverableChannel) {
+      RecoverableChannel rc = (RecoverableChannel) channel;
       rc.addRecoveryListener(
           new RecoveryListener() {
             @Override

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
@@ -55,25 +55,27 @@ public class RabbitClient {
     // We need a recoverable connection since we don't want to handle connection and channel
     // recovery ourselves.
     if (channel instanceof RecoverableChannel rc) {
-      rc.addRecoveryListener(new RecoveryListener() {
-        @Override
-        public void handleRecovery(Recoverable recoverable) {
-          // Whenever a connection has failed and is then automatically recovered, we want to reset
-          // the availability flag and signal all threads that are currently waiting for the
-          // connection's channel to become available again so they can retry their respective
-          // channel operation.
-          log.info("Connection recovered");
-          channelAvailable = true;
-          channelLock.lock();
-          channelAvailableAgain.signal();
-          channelLock.unlock();
-        }
+      rc.addRecoveryListener(
+          new RecoveryListener() {
+            @Override
+            public void handleRecovery(Recoverable recoverable) {
+              // Whenever a connection has failed and is then automatically recovered, we want to
+              // reset
+              // the availability flag and signal all threads that are currently waiting for the
+              // connection's channel to become available again so they can retry their respective
+              // channel operation.
+              log.info("Connection recovered");
+              channelAvailable = true;
+              channelLock.lock();
+              channelAvailableAgain.signal();
+              channelLock.unlock();
+            }
 
-        @Override
-        public void handleRecoveryStarted(Recoverable recoverable) {
-          // NOP
-        }
-      });
+            @Override
+            public void handleRecoveryStarted(Recoverable recoverable) {
+              // NOP
+            }
+          });
     } else {
       throw new RuntimeException("Flusswerk needs a recoverable connection to RabbitMQ");
     }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
@@ -68,7 +68,7 @@ public class RabbitClient {
               log.info("Connection recovered.");
               channelAvailable = true;
               channelLock.lock();
-              channelAvailableAgain.signal();
+              channelAvailableAgain.signalAll();
               channelLock.unlock();
             }
 

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
@@ -154,14 +154,14 @@ public class RabbitClient {
     }
   }
 
-  public Message receive(String queueName) throws InvalidMessageException {
+  public Message receive(String queueName, boolean autoAck) throws InvalidMessageException {
     GetResponse response;
     // The channel might not be available or become unavailable due to a connection error. In this
     // case, we wait until the connection becomes available again.
     while (true) {
       if (channelAvailable) {
         try {
-          response = channel.basicGet(queueName, NO_AUTO_ACK);
+          response = channel.basicGet(queueName, autoAck);
           break;
         } catch (IOException | AlreadyClosedException e) {
           log.warn("Failed to receive message from RabbitMQ: {}", e.getMessage(), e);

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitConnection.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitConnection.java
@@ -51,7 +51,7 @@ public class RabbitConnection {
     return channel;
   }
 
-  final void waitForConnection() throws IOException {
+  private void waitForConnection() throws IOException {
     List<Address> addresses =
         rabbitMQ.getHosts().stream().map(Address::parseAddress).collect(Collectors.toList());
     boolean connectionIsFailing = true;

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitConnection.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitConnection.java
@@ -37,6 +37,10 @@ public class RabbitConnection {
     factory.setUsername(rabbitMQ.getUsername());
     factory.setPassword(rabbitMQ.getPassword());
     rabbitMQ.getVirtualHost().ifPresent(factory::setVirtualHost);
+    factory.setConnectionRecoveryTriggeringCondition(
+        sse -> {
+          return !sse.isInitiatedByApplication();
+        });
     waitForConnection();
   }
 

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/MessageBrokerTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/MessageBrokerTest.java
@@ -104,14 +104,14 @@ class MessageBrokerTest {
   void receiveShouldPullTheSpecifiedQueue() throws IOException, InvalidMessageException {
     String queue = "a.very.special.queue";
     messageBroker.receive(queue);
-    verify(rabbitClient).receive(queue);
+    verify(rabbitClient).receive(queue, false);
   }
 
   @Test
   @DisplayName("Default receive should pull from the input queue")
   void defaultReceiveShouldPullTheInputQueue() throws IOException, InvalidMessageException {
     messageBroker.receive();
-    verify(rabbitClient).receive(routing.getIncoming().get(0));
+    verify(rabbitClient).receive(routing.getIncoming().get(0), false);
   }
 
   @Test
@@ -140,7 +140,7 @@ class MessageBrokerTest {
     envelope.setDeliveryTag(1);
     envelope.setBody(invalidMessageBody);
     envelope.setSource("some.input.queue");
-    when(rabbitClient.receive(eq("some.input.queue")))
+    when(rabbitClient.receive(eq("some.input.queue"), eq(false)))
         .thenThrow(new InvalidMessageException(envelope, "Invalid message"));
 
     Assertions.assertThat(messageBroker.receive()).isNull();

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/QueueTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/QueueTest.java
@@ -48,8 +48,8 @@ class QueueTest {
   @Test
   void receive() throws IOException, InvalidMessageException {
     var expected = new Message();
-    when(rabbitClient.receive(queue.getName())).thenReturn(expected);
-    assertThat(queue.receive()).contains(expected);
+    when(rabbitClient.receive(queue.getName(), false)).thenReturn(expected);
+    assertThat(queue.receive(false)).contains(expected);
   }
 
   @Test

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClientTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClientTest.java
@@ -94,7 +94,7 @@ class RabbitClientTest {
     String body = new String(response.getBody(), StandardCharsets.UTF_8);
 
     when(channel.basicGet(inputQueue, false)).thenReturn(response);
-    Message message = rabbitClient.receive(inputQueue);
+    Message message = rabbitClient.receive(inputQueue, false);
     assertThat(message.getEnvelope())
         .returns(body, from(Envelope::getBody))
         .returns(deliveryTag, from(Envelope::getDeliveryTag))
@@ -149,7 +149,7 @@ class RabbitClientTest {
     RabbitClient rabbitClient = new RabbitClient(connection);
 
     InvalidMessageException thrown =
-        assertThrows(InvalidMessageException.class, () -> rabbitClient.receive("test"));
+        assertThrows(InvalidMessageException.class, () -> rabbitClient.receive("test", false));
     assertThat(thrown.getMessage()).startsWith("Unrecognized token 'NoValidJson'");
   }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClientTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClientTest.java
@@ -19,6 +19,7 @@ import com.github.dbmdz.flusswerk.framework.model.Message;
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.GetResponse;
+import com.rabbitmq.client.RecoverableChannel;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -38,7 +39,7 @@ class RabbitClientTest {
   @BeforeEach
   void setUp() {
     connection = mock(RabbitConnection.class);
-    channel = mock(Channel.class);
+    channel = mock(RecoverableChannel.class);
     when(connection.getChannel()).thenReturn(channel);
     message = new Message();
   }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -74,6 +74,11 @@
       <version>1.17.5</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>toxiproxy</artifactId>
+      <version>1.17.5</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -56,6 +56,24 @@
       <artifactId>spring-boot-actuator-autoconfigure</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>1.17.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>1.17.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>rabbitmq</artifactId>
+      <version>1.17.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/NoFlowTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/NoFlowTest.java
@@ -4,13 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.dbmdz.flusswerk.framework.config.FlusswerkConfiguration;
 import com.github.dbmdz.flusswerk.framework.config.FlusswerkPropertiesConfiguration;
+import com.github.dbmdz.flusswerk.framework.config.properties.RabbitMQProperties;
 import com.github.dbmdz.flusswerk.framework.config.properties.RoutingProperties;
 import com.github.dbmdz.flusswerk.framework.engine.Engine;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.model.Message;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
 import com.github.dbmdz.flusswerk.integration.NoFlowTest.NoFlowTestConfiguration;
 import java.io.IOException;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,11 +25,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest
+@SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
 @ContextConfiguration(
     classes = {
       FlusswerkPropertiesConfiguration.class,
@@ -35,10 +42,28 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
     })
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When Flusswerk is created without a Flow")
+@Testcontainers
 public class NoFlowTest {
+  @Container
+  static RabbitMQContainer rabbitMQContainer =
+      new RabbitMQContainer("rabbitmq:3-management-alpine");
 
   @TestConfiguration
   static class NoFlowTestConfiguration {
+    @Bean
+    @Primary
+    public RabbitConnection rabbitConnection() throws IOException {
+      return new RabbitConnection(
+          new RabbitMQProperties(
+              List.of(
+                  String.format(
+                      "%s:%d", rabbitMQContainer.getHost(), rabbitMQContainer.getAmqpPort())),
+              "/",
+              "guest",
+              "guest"),
+          "no-flow-test");
+    }
+
     @Bean
     public IncomingMessageType incomingMessageType() {
       return new IncomingMessageType(TestMessage.class);

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/RabbitUtil.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/RabbitUtil.java
@@ -43,35 +43,45 @@ public class RabbitUtil {
     rabbitMQ.topic(firstInput()).send(message);
   }
 
-  private Message checkedReceive(String queueName)
+  private Message checkedReceive(String queueName, boolean autoAck)
       throws InvalidMessageException, IOException, InterruptedException {
     var queue = rabbitMQ.queue(queueName);
     Thread.sleep(10); // wait for message to arrive
-    Optional<Message> received = queue.receive();
+    Optional<Message> received = queue.receive(autoAck);
     if (received.isEmpty()) {
       Thread.sleep(1_000); // wait more in case first wait was not enough
-      received = queue.receive();
+      received = queue.receive(autoAck);
     }
     if (received.isEmpty()) {
       throw new RuntimeException("No message received");
     }
     Message message = received.get();
-    rabbitMQ.ack(message);
+    if (!autoAck) {
+      rabbitMQ.ack(message);
+    }
     return message;
   }
 
   public Message receive() {
+    return receive(false);
+  }
+
+  public Message receive(boolean autoAck) {
     try {
-      return checkedReceive(output());
+      return checkedReceive(output(), autoAck);
     } catch (InterruptedException | InvalidMessageException | IOException e) {
       throw new RuntimeException(e);
     }
   }
 
   public Message receiveFailed() {
+    return receiveFailed(false);
+  }
+
+  public Message receiveFailed(boolean autoAck) {
     String failedQueue = routing.getFailurePolicy(firstInput()).getFailedRoutingKey();
     try {
-      return checkedReceive(failedQueue);
+      return checkedReceive(failedQueue, autoAck);
     } catch (InterruptedException | InvalidMessageException | IOException e) {
       throw new RuntimeException(e);
     }

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/RabbitUtil.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/RabbitUtil.java
@@ -49,7 +49,7 @@ public class RabbitUtil {
     Thread.sleep(10); // wait for message to arrive
     Optional<Message> received = queue.receive(autoAck);
     if (received.isEmpty()) {
-      Thread.sleep(1_000); // wait more in case first wait was not enough
+      Thread.sleep(2000); // wait more in case first wait was not enough
       received = queue.receive(autoAck);
     }
     if (received.isEmpty()) {

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/ReconnectTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/ReconnectTest.java
@@ -15,13 +15,20 @@ import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
 import com.github.dbmdz.flusswerk.integration.RabbitUtil;
 import com.github.dbmdz.flusswerk.integration.TestMessage;
+import eu.rekawek.toxiproxy.Proxy;
+import eu.rekawek.toxiproxy.ToxiproxyClient;
+import eu.rekawek.toxiproxy.model.ToxicDirection;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.List;
+import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
@@ -34,7 +41,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.containers.Network;
 import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -44,24 +53,38 @@ import org.testcontainers.junit.jupiter.Testcontainers;
     classes = {
       FlusswerkPropertiesConfiguration.class,
       FlusswerkConfiguration.class,
-      SuccessfulProcessingTest.FlowConfiguration.class
+      ReconnectTest.FlowConfiguration.class
     })
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
-@DisplayName("When Flusswerk successfully processes a message")
+@DisplayName("When the RabbitMQ connection is lost")
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 @Testcontainers
-public class SuccessfulProcessingTest {
+public class ReconnectTest {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Rule static final Network network = Network.newNetwork();
+
   @Container
-  static RabbitMQContainer rabbitMQContainer =
-      new RabbitMQContainer("rabbitmq:3-management-alpine");
+  static final RabbitMQContainer rabbitMQContainer =
+      new RabbitMQContainer("rabbitmq:3-management-alpine")
+          .withNetwork(network)
+          .withExposedPorts(5672)
+          .withNetworkAliases("rabbitmq");
+
+  @Rule
+  static final ToxiproxyContainer toxiProxy =
+      new ToxiproxyContainer("ghcr.io/shopify/toxiproxy:2.5.0")
+          .withExposedPorts(5672, 8474)
+          .withNetwork(network);
+
+  static Proxy proxy;
 
   private final Engine engine;
 
   private final RabbitUtil rabbitUtil;
 
   @Autowired
-  public SuccessfulProcessingTest(
-      Engine engine, RoutingProperties routingProperties, RabbitMQ rabbitMQ) {
+  public ReconnectTest(Engine engine, RoutingProperties routingProperties, RabbitMQ rabbitMQ) {
     this.engine = engine;
     rabbitUtil = new RabbitUtil(rabbitMQ, routingProperties);
   }
@@ -71,15 +94,19 @@ public class SuccessfulProcessingTest {
     @Bean
     @Primary
     public RabbitConnection rabbitConnection() throws IOException {
+      // Need to have the containers started go get the host and port mappings
+      rabbitMQContainer.start();
+      toxiProxy.start();
+      final ToxiproxyClient toxiProxyClient =
+          new ToxiproxyClient(toxiProxy.getHost(), toxiProxy.getControlPort());
+      proxy = toxiProxyClient.createProxy("rabbitmq", "0.0.0.0:5672", "rabbitmq:5672");
       return new RabbitConnection(
           new RabbitMQProperties(
-              List.of(
-                  String.format(
-                      "%s:%d", rabbitMQContainer.getHost(), rabbitMQContainer.getAmqpPort())),
+              List.of(String.format("%s:%d", toxiProxy.getHost(), toxiProxy.getMappedPort(5672))),
               "/",
               "guest",
               "guest"),
-          "no-flow-test");
+          "reconnect-test");
     }
 
     @Bean
@@ -89,7 +116,35 @@ public class SuccessfulProcessingTest {
 
     @Bean
     public FlowSpec flowSpec() {
-      return FlowBuilder.messageProcessor(TestMessage.class).process(m -> m).build();
+      return FlowBuilder.flow(TestMessage.class, String.class, String.class)
+          .reader(
+              msg -> {
+                try {
+                  Thread.sleep(100);
+                } catch (InterruptedException e) {
+                  throw new RuntimeException(e);
+                }
+                return msg.getId();
+              })
+          .transformer(
+              msg -> {
+                try {
+                  Thread.sleep(100);
+                } catch (InterruptedException e) {
+                  throw new RuntimeException(e);
+                }
+                return msg.toUpperCase();
+              })
+          .writerSendingMessage(
+              msg -> {
+                try {
+                  Thread.sleep(100);
+                } catch (InterruptedException e) {
+                  throw new RuntimeException(e);
+                }
+                return new TestMessage(msg);
+              })
+          .build();
     }
   }
 
@@ -100,6 +155,7 @@ public class SuccessfulProcessingTest {
 
   @AfterEach
   void stopEngine() throws IOException {
+    // FIXME: Stopping fails due to bad delivery tags, why is that?
     engine.stop();
     rabbitUtil.purgeQueues();
   }
@@ -107,12 +163,28 @@ public class SuccessfulProcessingTest {
   @DisplayName("then the message should end up in the output queue")
   @Test
   public void successfulMessagesShouldGoToOutQueue() throws Exception {
-    TestMessage expected = new TestMessage("123456");
+    TestMessage input = new TestMessage("hello world");
 
-    rabbitUtil.send(expected);
+    log.info("Sending message");
+    rabbitUtil.send(input);
+    log.info("Disrupting RabbitMQ connection");
+    // Stop letting packets through and close the connection after 1sec
+    proxy.toxics().timeout("timeout", ToxicDirection.DOWNSTREAM, 1000);
+    // Leave the engine alone for 15secs
+    Thread.sleep(15000);
+    log.info("Re-establishing RabbitMQ connection");
+    proxy.toxics().get("timeout").remove();
+    log.info("Checking that connection has recovered by fetching a message ");
     var received = (TestMessage) rabbitUtil.receive();
+    assertThat(received.getId()).isEqualTo("HELLO WORLD");
+    assertThat(rabbitUtil).allQueuesAreEmpty();
 
-    assertThat(received.getId()).isEqualTo(expected.getId());
+    // Any subsequent  messages should go through without any additional delay
+    input = new TestMessage("and now again");
+    rabbitUtil.send(input);
+    received = (TestMessage) rabbitUtil.receive();
+    assertThat(received.getId()).isEqualTo("AND NOW AGAIN");
+    // FIXME: This assertion fails, why?
     assertThat(rabbitUtil).allQueuesAreEmpty();
   }
 }

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/RetryTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/RetryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.dbmdz.flusswerk.framework.config.FlusswerkConfiguration;
 import com.github.dbmdz.flusswerk.framework.config.FlusswerkPropertiesConfiguration;
+import com.github.dbmdz.flusswerk.framework.config.properties.RabbitMQProperties;
 import com.github.dbmdz.flusswerk.framework.config.properties.RoutingProperties;
 import com.github.dbmdz.flusswerk.framework.engine.Engine;
 import com.github.dbmdz.flusswerk.framework.exceptions.RetryProcessingException;
@@ -12,10 +13,12 @@ import com.github.dbmdz.flusswerk.framework.flow.FlowSpec;
 import com.github.dbmdz.flusswerk.framework.flow.builder.FlowBuilder;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.model.Message;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
 import com.github.dbmdz.flusswerk.integration.RabbitUtil;
 import com.github.dbmdz.flusswerk.integration.TestMessage;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.junit.jupiter.api.AfterEach;
@@ -30,23 +33,32 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest
+@SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
 @ContextConfiguration(
     classes = {
-      RetryTest.FlowConfiguration.class,
       FlusswerkPropertiesConfiguration.class,
-      FlusswerkConfiguration.class
+      FlusswerkConfiguration.class,
+      RetryTest.FlowConfiguration.class,
     })
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When processing for a message fails")
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+@Testcontainers
 public class RetryTest {
+
+  @Container
+  static RabbitMQContainer rabbitMQContainer =
+      new RabbitMQContainer("rabbitmq:3-management-alpine");
 
   private final Engine engine;
 
@@ -70,6 +82,20 @@ public class RetryTest {
 
   @TestConfiguration
   static class FlowConfiguration {
+    @Bean
+    @Primary
+    public RabbitConnection rabbitConnection() throws IOException {
+      return new RabbitConnection(
+          new RabbitMQProperties(
+              List.of(
+                  String.format(
+                      "%s:%d", rabbitMQContainer.getHost(), rabbitMQContainer.getAmqpPort())),
+              "/",
+              "guest",
+              "guest"),
+          "no-flow-test");
+    }
+
     @Bean
     public IncomingMessageType incomingMessageType() {
       return new IncomingMessageType(TestMessage.class);

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/SkipProcessingTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/SkipProcessingTest.java
@@ -5,16 +5,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.dbmdz.flusswerk.framework.config.FlusswerkConfiguration;
 import com.github.dbmdz.flusswerk.framework.config.FlusswerkPropertiesConfiguration;
+import com.github.dbmdz.flusswerk.framework.config.properties.RabbitMQProperties;
 import com.github.dbmdz.flusswerk.framework.config.properties.RoutingProperties;
 import com.github.dbmdz.flusswerk.framework.engine.Engine;
 import com.github.dbmdz.flusswerk.framework.exceptions.SkipProcessingException;
 import com.github.dbmdz.flusswerk.framework.flow.FlowSpec;
 import com.github.dbmdz.flusswerk.framework.flow.builder.FlowBuilder;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
 import com.github.dbmdz.flusswerk.integration.RabbitUtil;
 import com.github.dbmdz.flusswerk.integration.TestMessage;
 import java.io.IOException;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,23 +30,32 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest
+@SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
 @ContextConfiguration(
     classes = {
-      SkipProcessingTest.FlowConfiguration.class,
       FlusswerkPropertiesConfiguration.class,
-      FlusswerkConfiguration.class
+      FlusswerkConfiguration.class,
+      SkipProcessingTest.FlowConfiguration.class,
     })
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When Flusswerk skips a message")
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+@Testcontainers
 public class SkipProcessingTest {
+
+  @Container
+  static RabbitMQContainer rabbitMQContainer =
+      new RabbitMQContainer("rabbitmq:3-management-alpine");
 
   private final Engine engine;
 
@@ -57,6 +69,20 @@ public class SkipProcessingTest {
 
   @TestConfiguration
   static class FlowConfiguration {
+    @Bean
+    @Primary
+    public RabbitConnection rabbitConnection() throws IOException {
+      return new RabbitConnection(
+          new RabbitMQProperties(
+              List.of(
+                  String.format(
+                      "%s:%d", rabbitMQContainer.getHost(), rabbitMQContainer.getAmqpPort())),
+              "/",
+              "guest",
+              "guest"),
+          "no-flow-test");
+    }
+
     @Bean
     public IncomingMessageType incomingMessageType() {
       return new IncomingMessageType(TestMessage.class);

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/SuccessfulProcessingTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/SuccessfulProcessingTest.java
@@ -5,15 +5,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.dbmdz.flusswerk.framework.config.FlusswerkConfiguration;
 import com.github.dbmdz.flusswerk.framework.config.FlusswerkPropertiesConfiguration;
+import com.github.dbmdz.flusswerk.framework.config.properties.RabbitMQProperties;
 import com.github.dbmdz.flusswerk.framework.config.properties.RoutingProperties;
 import com.github.dbmdz.flusswerk.framework.engine.Engine;
 import com.github.dbmdz.flusswerk.framework.flow.FlowSpec;
 import com.github.dbmdz.flusswerk.framework.flow.builder.FlowBuilder;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
 import com.github.dbmdz.flusswerk.integration.RabbitUtil;
 import com.github.dbmdz.flusswerk.integration.TestMessage;
 import java.io.IOException;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,23 +29,31 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest
+@SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
 @ContextConfiguration(
     classes = {
-      SuccessfulProcessingTest.FlowConfiguration.class,
       FlusswerkPropertiesConfiguration.class,
-      FlusswerkConfiguration.class
+      FlusswerkConfiguration.class,
+      SuccessfulProcessingTest.FlowConfiguration.class
     })
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When Flusswerk successfully processes a message")
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+@Testcontainers
 public class SuccessfulProcessingTest {
+  @Container
+  static RabbitMQContainer rabbitMQContainer =
+      new RabbitMQContainer("rabbitmq:3-management-alpine");
 
   private final Engine engine;
 
@@ -57,6 +68,24 @@ public class SuccessfulProcessingTest {
 
   @TestConfiguration
   static class FlowConfiguration {
+    @Bean
+    @Primary
+    public RabbitConnection rabbitConnection() throws IOException {
+      var containerId = rabbitMQContainer.getContainerId();
+      var docker = rabbitMQContainer.getDockerClient();
+      try (var cmd = docker.pauseContainerCmd(containerId)) {
+        cmd.exec();
+      }
+      return new RabbitConnection(
+          new RabbitMQProperties(
+              List.of(
+                  String.format(
+                      "%s:%d", rabbitMQContainer.getHost(), rabbitMQContainer.getAmqpPort())),
+              "/",
+              "guest",
+              "guest"),
+          "no-flow-test");
+    }
 
     @Bean
     public IncomingMessageType incomingMessageType() {

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
   </modules>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Dependency versions -->
     <version.amqp-client>5.14.2</version.amqp-client>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
   </modules>
 
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Dependency versions -->
     <version.amqp-client>5.14.2</version.amqp-client>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.4</version>
+    <version>2.7.5</version>
   </parent>
 
   <description>


### PR DESCRIPTION
Previously Flusswerk implemented a custom connection recovery mechanism that had a fair amount of problems, most importantly a deadlocked application in case of connection loss with outstanding messages.

This change modifies Flusswerk to use the recovery mechanism baked into the RabbitMQ Java client library, which in addition to making the connection recovery work reliably, simplifies the API for users, since most methods on `RabbitClient` no longer throw an `IOException`.