### PR TITLE
Bump version to 5.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.1.1] - 2022-11-14
 ### Fixed
 
-- Rely on automatic connection recovery instead of managing it manually ([#410](https://github.com/dbmdz/flusswerk/pull/410/commits))
+- Rely on automatic connection recovery instead of managing it manually ([#410](https://github.com/dbmdz/flusswerk/pull/410))
 - Flusswerk metrics separated from application metrics ([#405](https://github.com/dbmdz/flusswerk/pull/405))
 - Tracing information added to messages send with `SkipProcessingException` ([#404](https://github.com/dbmdz/flusswerk/pull/404))
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.1] - 2022-11-14
+### Fixed
+
+- Rely on automatic connection recovery instead of managing it manually ([#410](https://github.com/dbmdz/flusswerk/pull/410/commits))
+- Flusswerk metrics separated from application metrics ([#405](https://github.com/dbmdz/flusswerk/pull/405))
+- Tracing information added to messages send with `SkipProcessingException` ([#404](https://github.com/dbmdz/flusswerk/pull/404))
+
 ## [5.1.0] - 2022-05-18
 ### Added
 

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>5.1.1-SNAPSHOT</version>
+    <version>5.1.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.github.dbmdz.flusswerk</groupId>
     <artifactId>flusswerk</artifactId>
-    <version>5.1.1-SNAPSHOT</version>
+    <version>5.1.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.dbmdz.flusswerk</groupId>
   <artifactId>flusswerk</artifactId>
-  <version>5.1.1-SNAPSHOT</version>
+  <version>5.1.1</version>
   <packaging>pom</packaging>
 
   <name>Flusswerk</name>
@@ -72,7 +72,7 @@
     <version.amqp-client>5.14.2</version.amqp-client>
     <version.byte-buddy>1.12.18</version.byte-buddy>
     <version.logstash-encoder>7.2</version.logstash-encoder>
-    <version.flusswerk>5.1.1-SNAPSHOT</version.flusswerk>
+    <version.flusswerk>5.1.1</version.flusswerk>
     <version.junit>5.7.0</version.junit>
     <version.mockito>4.8.1</version.mockito>
     <!-- Plugin versions -->


### PR DESCRIPTION
### Fixed

- Rely on automatic connection recovery instead of managing it manually ([#410](https://github.com/dbmdz/flusswerk/pull/410/commits))
- Flusswerk metrics separated from application metrics ([#405](https://github.com/dbmdz/flusswerk/pull/405))
- Tracing information added to messages send with `SkipProcessingException` ([#404](https://github.com/dbmdz/flusswerk/pull/404))