### PR TITLE
Configure FlusswerkObjectMapper to support Java 8 features

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -26,6 +26,14 @@
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-parameter-names</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
     </dependency>

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/jackson/FlusswerkObjectMapper.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/jackson/FlusswerkObjectMapper.java
@@ -2,7 +2,9 @@ package com.github.dbmdz.flusswerk.framework.jackson;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import com.github.dbmdz.flusswerk.framework.model.Envelope;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.model.Message;
@@ -20,6 +22,8 @@ public class FlusswerkObjectMapper extends ObjectMapper {
     }
     addMixIn(Envelope.class, EnvelopeMixin.class);
     registerModule(new JavaTimeModule());
+    registerModule(new ParameterNamesModule());
+    registerModule(new Jdk8Module());
   }
 
   public Message deserialize(String json) throws JsonProcessingException {


### PR DESCRIPTION
`FlusswerkObjectMapper` should
* detect constructor and factory method parameters without having to use `@JsonProperty` annotation 
* support Java 8 datatypes like `Optional`