### PR TITLE
Record processing time in seconds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- The Counter `flusswerk_messages_seconds` now records the processing time in seconds
+
 ### Changed
 
 - Migrated to SpringBoot 3 / JDK17
+- `flowInfo.duration()` returns a `Duration` object instead of `long`
 
 ## [5.1.1] - 2022-11-14
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -305,10 +305,10 @@ code. Log messages and metrics will have `status=skip` to indicate that processi
 Every Flusswerk application provides base metrics via as a
 [Prometheus][Prometheus] endpoint:
 
-|                             |                                                         |
-| --------------------------- | ------------------------------------------------------- |
-| `flusswerk.processed.items` | total number of processed items since application start |
-| `flusswerk.execution.time`  | total amount of time spend on processing these items    |
+|                              |                                                            |
+|------------------------------|------------------------------------------------------------|
+| `flusswerk.messages`         | total number of processed messages since application start |
+| `flusswerk.messages.seconds` | total amount of time spent on processing these messages    |
 
 To include custom metrics, get counters via [MeterFactory][MeterFactory]. A bean
 of type [FlowMetrics][FlowMetrics] can also consume execution information of

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/FlowInfo.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/flow/FlowInfo.java
@@ -5,6 +5,7 @@ import com.github.dbmdz.flusswerk.framework.exceptions.StopProcessingException;
 import com.github.dbmdz.flusswerk.framework.flow.builder.ConfigurationStep;
 import com.github.dbmdz.flusswerk.framework.model.Message;
 import com.github.dbmdz.flusswerk.framework.monitoring.Status;
+import java.time.Duration;
 
 /**
  * Collect base metrics for a single flow - did the execution have errors and how long does it take?
@@ -20,13 +21,13 @@ public class FlowInfo {
   private final Message message;
 
   public FlowInfo(Message message) {
-    this.startTime = System.currentTimeMillis();
+    this.startTime = System.nanoTime();
     this.status = Status.SUCCESS;
     this.message = message;
   }
 
   public void stop() {
-    this.endTime = System.currentTimeMillis();
+    this.endTime = System.nanoTime();
   }
 
   public Status getStatus() {
@@ -47,7 +48,7 @@ public class FlowInfo {
     return message;
   }
 
-  public long duration() {
-    return this.endTime - this.startTime;
+  public Duration duration() {
+    return Duration.ofNanos(this.endTime - this.startTime);
   }
 }

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/FlusswerkMetrics.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/FlusswerkMetrics.java
@@ -65,6 +65,6 @@ public class FlusswerkMetrics implements FlowMetrics {
   public void accept(FlowInfo flowInfo) {
     Status status = flowInfo.getStatus();
     messagesTotal.get(status).increment();
-    messagesSeconds.get(status).increment(flowInfo.duration());
+    messagesSeconds.get(status).increment(flowInfo.duration().getSeconds());
   }
 }


### PR DESCRIPTION
This PR fixes the time unit for `flusswerk.messages.seconds`.