### PR TITLE
Refactor RabbitMQ access API and package visibility

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -14,8 +14,8 @@ import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.monitoring.FlowMetrics;
 import com.github.dbmdz.flusswerk.framework.monitoring.FlusswerkMetrics;
 import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
 import com.github.dbmdz.flusswerk.framework.reporting.DefaultProcessReport;
 import com.github.dbmdz.flusswerk.framework.reporting.ProcessReport;
 import com.github.dbmdz.flusswerk.framework.reporting.Tracing;
@@ -29,7 +29,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-/** Spring configuration to provide beans for{@link MessageBroker} and {@link Engine}. */
 @Configuration
 @Import(FlusswerkPropertiesConfiguration.class)
 public class FlusswerkConfiguration {
@@ -75,10 +74,10 @@ public class FlusswerkConfiguration {
   public List<Worker> workers(
       AppProperties appProperties,
       Optional<Flow> flow,
-      MessageBroker messageBroker,
       ProcessingProperties processingProperties,
       Optional<ProcessReport> processReport,
       PriorityBlockingQueue<Task> taskQueue,
+      RabbitMQ rabbitMQ,
       Tracing tracing,
       FlusswerkMetrics metrics) {
     return flow.map(
@@ -89,10 +88,10 @@ public class FlusswerkConfiguration {
                             new Worker(
                                 theFlow,
                                 metrics,
-                                messageBroker,
                                 processReport.orElseGet(
                                     () -> new DefaultProcessReport(appProperties.name())),
                                 taskQueue,
+                                rabbitMQ,
                                 tracing))
                     .collect(
                         Collectors.toList())) // Return workers for each thread to process the Flow

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -1,6 +1,8 @@
 package com.github.dbmdz.flusswerk.framework.config;
 
-import com.github.dbmdz.flusswerk.framework.config.properties.*;
+import com.github.dbmdz.flusswerk.framework.config.properties.AppProperties;
+import com.github.dbmdz.flusswerk.framework.config.properties.ProcessingProperties;
+import com.github.dbmdz.flusswerk.framework.config.properties.RoutingProperties;
 import com.github.dbmdz.flusswerk.framework.engine.Engine;
 import com.github.dbmdz.flusswerk.framework.engine.FlusswerkConsumer;
 import com.github.dbmdz.flusswerk.framework.engine.Task;
@@ -13,14 +15,10 @@ import com.github.dbmdz.flusswerk.framework.monitoring.FlowMetrics;
 import com.github.dbmdz.flusswerk.framework.monitoring.FlusswerkMetrics;
 import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitClient;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
 import com.github.dbmdz.flusswerk.framework.reporting.DefaultProcessReport;
 import com.github.dbmdz.flusswerk.framework.reporting.ProcessReport;
 import com.github.dbmdz.flusswerk.framework.reporting.Tracing;
-import io.micrometer.core.instrument.MeterRegistry;
-import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.Semaphore;
@@ -37,15 +35,10 @@ import org.springframework.context.annotation.Import;
 public class FlusswerkConfiguration {
 
   @Bean
-  public Tracing tracing() {
-    return new Tracing();
-  }
-
-  @Bean
   public Flow flow(Optional<FlowSpec> flowSpec) {
     // No FlowSpec → no Flow. We will have to handle this case when creating the
     // Engine bean as the sole consumer of the Flow bean.
-    return flowSpec.map(spec -> new Flow(spec)).orElse(null);
+    return flowSpec.map(Flow::new).orElse(null);
   }
 
   @Bean
@@ -68,42 +61,9 @@ public class FlusswerkConfiguration {
   }
 
   @Bean
-  public MeterFactory meterFactory(
-      MonitoringProperties monitoringProperties, MeterRegistry meterRegistry) {
-    return new MeterFactory(monitoringProperties.prefix(), meterRegistry);
-  }
-
-  @Bean
   public FlusswerkObjectMapper flusswerkObjectMapper(
       ObjectProvider<IncomingMessageType> incomingMessageType) {
     return new FlusswerkObjectMapper(incomingMessageType.getIfAvailable(IncomingMessageType::new));
-  }
-
-  @Bean
-  public RabbitConnection rabbitConnection(
-      AppProperties appProperties, RabbitMQProperties rabbitMQProperties) throws IOException {
-    return new RabbitConnection(rabbitMQProperties, appProperties.name());
-  }
-
-  @Bean
-  public RabbitClient rabbitClient(
-      FlusswerkObjectMapper flusswerkObjectMapper, RabbitConnection rabbitConnection) {
-    return new RabbitClient(flusswerkObjectMapper, rabbitConnection);
-  }
-
-  @Bean
-  public RabbitMQ rabbitMQ(
-      RoutingProperties routingProperties,
-      RabbitClient rabbitClient,
-      MessageBroker messageBroker,
-      Tracing tracing) {
-    return new RabbitMQ(routingProperties, rabbitClient, messageBroker, tracing);
-  }
-
-  @Bean
-  public MessageBroker messageBroker(RoutingProperties routingProperties, RabbitClient rabbitClient)
-      throws IOException {
-    return new MessageBroker(routingProperties, rabbitClient);
   }
 
   @Bean
@@ -137,12 +97,6 @@ public class FlusswerkConfiguration {
                     .collect(
                         Collectors.toList())) // Return workers for each thread to process the Flow
         .orElse(Collections.emptyList()); // No Flow, nothing to do
-  }
-
-  @Bean
-  public FlusswerkMetrics metrics(
-      ProcessingProperties processingProperties, MeterRegistry meterRegistry) {
-    return new FlusswerkMetrics(processingProperties, meterRegistry);
   }
 
   @Bean

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/engine/Engine.java
@@ -1,23 +1,15 @@
 package com.github.dbmdz.flusswerk.framework.engine;
 
 import com.github.dbmdz.flusswerk.framework.flow.Flow;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
 import com.rabbitmq.client.Channel;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.PriorityBlockingQueue;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Run flows {@link Flow} for every message from the {@link MessageBroker} - usually several in
- * parallel.
- */
+/** Run flows {@link Flow} for every message from RabbitMQ - usually several in parallel. */
 public class Engine {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Engine.class);

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/FlusswerkMetrics.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/FlusswerkMetrics.java
@@ -10,7 +10,9 @@ import java.util.EnumMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.stereotype.Component;
 
+@Component
 public class FlusswerkMetrics implements FlowMetrics {
 
   private final AtomicInteger activeWorkers = new AtomicInteger(0);

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/MeterFactory.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/monitoring/MeterFactory.java
@@ -2,15 +2,24 @@ package com.github.dbmdz.flusswerk.framework.monitoring;
 
 import static java.util.Arrays.asList;
 
+import com.github.dbmdz.flusswerk.framework.config.properties.MonitoringProperties;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 /** Convenience factory to simplify the creation of {@link Counter} meters. */
+@Component
 public class MeterFactory {
   private final String basename;
   private final MeterRegistry registry;
+
+  @Autowired
+  public MeterFactory(MonitoringProperties monitoringProperties, MeterRegistry registry) {
+    this(monitoringProperties.prefix(), registry);
+  }
 
   /**
    * @param basename The prefix for the created metrics ("e.g. flusswerk for flusswerk.items.total")

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/MessageBroker.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/MessageBroker.java
@@ -5,7 +5,6 @@ import com.github.dbmdz.flusswerk.framework.exceptions.InvalidMessageException;
 import com.github.dbmdz.flusswerk.framework.model.Envelope;
 import com.github.dbmdz.flusswerk.framework.model.Message;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +16,7 @@ import org.springframework.stereotype.Component;
  * for messages.
  */
 @Component
-public class MessageBroker {
+class MessageBroker {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MessageBroker.class);
   private static final String MESSAGE_TTL = "x-message-ttl";
@@ -37,22 +36,6 @@ public class MessageBroker {
   }
 
   /**
-   * Sends messages to the default output queue as JSON document.
-   *
-   * @param messages the message to send.
-   * @throws IOException if sending the message fails.
-   * @deprecated Use {@link Topic#send(Message)} instead
-   */
-  @Deprecated
-  public void send(Collection<? extends Message> messages) throws IOException {
-    var topic = routingConfig.getOutgoing().get("default");
-    if (topic == null) {
-      throw new RuntimeException("Cannot send messages, no default queue specified");
-    }
-    send(topic, messages);
-  }
-
-  /**
    * Sends a message to a certain queue as JSON document.
    *
    * @param routingKey the routing key for the queue to send the message to (usually the queue
@@ -62,21 +45,6 @@ public class MessageBroker {
    */
   void send(String routingKey, Message message) throws IOException {
     rabbitClient.send(routingConfig.getExchange(routingKey), routingKey, message);
-  }
-
-  /**
-   * Sends multiple messages to a certain queue as JSON documents. The messages are sent in the same
-   * order as returned by the iterator over <code>messages</code>.
-   *
-   * @param routingKey the routing key for the queue to send the message to (usually the queue
-   *     name).
-   * @param messages the messages to send.
-   * @throws IOException if sending a message fails.
-   */
-  void send(String routingKey, Collection<? extends Message> messages) throws IOException {
-    for (Message message : messages) {
-      send(routingKey, message);
-    }
   }
 
   /**

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/Processing.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/Processing.java
@@ -1,0 +1,21 @@
+package com.github.dbmdz.flusswerk.framework.rabbitmq;
+
+import com.github.dbmdz.flusswerk.framework.model.Message;
+import java.io.IOException;
+
+public class Processing {
+
+  private MessageBroker messageBroker;
+
+  public Processing(MessageBroker messageBroker) {
+    this.messageBroker = messageBroker;
+  }
+
+  public void stop(Message message) throws IOException {
+    messageBroker.fail(message);
+  }
+
+  public boolean retry(Message message) throws IOException {
+    return messageBroker.reject(message);
+  }
+}

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
@@ -19,7 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class RabbitClient {
+class RabbitClient {
 
   private static final boolean DURABLE = true;
 

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitClient.java
@@ -6,14 +6,7 @@ import com.github.dbmdz.flusswerk.framework.jackson.FlusswerkObjectMapper;
 import com.github.dbmdz.flusswerk.framework.model.Envelope;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.model.Message;
-import com.rabbitmq.client.AMQP;
-import com.rabbitmq.client.AlreadyClosedException;
-import com.rabbitmq.client.BuiltinExchangeType;
-import com.rabbitmq.client.Channel;
-import com.rabbitmq.client.GetResponse;
-import com.rabbitmq.client.Recoverable;
-import com.rabbitmq.client.RecoverableChannel;
-import com.rabbitmq.client.RecoveryListener;
+import com.rabbitmq.client.*;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -22,7 +15,10 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class RabbitClient {
 
   private static final boolean DURABLE = true;
@@ -49,6 +45,7 @@ public class RabbitClient {
     this(new IncomingMessageType(), rabbitConnection);
   }
 
+  @Autowired
   public RabbitClient(FlusswerkObjectMapper flusswerkObjectMapper, RabbitConnection connection) {
     channel = connection.getChannel();
     // We need a recoverable connection since we don't want to handle connection and channel

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitConnection.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitConnection.java
@@ -1,5 +1,6 @@
 package com.github.dbmdz.flusswerk.framework.rabbitmq;
 
+import com.github.dbmdz.flusswerk.framework.config.properties.AppProperties;
 import com.github.dbmdz.flusswerk.framework.config.properties.RabbitMQProperties;
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Channel;
@@ -12,7 +13,10 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class RabbitConnection {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RabbitConnection.class);
@@ -24,6 +28,12 @@ public class RabbitConnection {
   private final String appName;
 
   private final RabbitMQProperties rabbitMQ;
+
+  @Autowired
+  public RabbitConnection(RabbitMQProperties rabbitMQ, AppProperties appProperties)
+      throws IOException {
+    this(rabbitMQ, new ConnectionFactory(), appProperties.name());
+  }
 
   public RabbitConnection(RabbitMQProperties rabbitMQ, String appName) throws IOException {
     this(rabbitMQ, new ConnectionFactory(), appName);

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitMQ.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitMQ.java
@@ -27,11 +27,7 @@ public class RabbitMQ {
    *
    * @param rabbitClient the connection to RabbitMQ.
    */
-  public RabbitMQ(
-      RoutingProperties routingProperties,
-      RabbitClient rabbitClient,
-      MessageBroker messageBroker,
-      Tracing tracing) {
+  public RabbitMQ(RoutingProperties routingProperties, RabbitClient rabbitClient, Tracing tracing) {
     this.tracing = tracing;
     // use RabbitConnection to prevent uncontrolled access to Channel from user app
     this.queues = new HashMap<>();

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/Topic.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/rabbitmq/Topic.java
@@ -51,7 +51,7 @@ public class Topic {
    * @throws IOException If communication with RabbitMQ fails or if the message cannot be serialized
    *     to JSON.
    */
-  public void send(Collection<Message> messages) throws IOException {
+  public void send(Collection<? extends Message> messages) throws IOException {
     // Get a new tracing path in case one is needed
     final List<String> tracingPath = getTracingPath();
     messages.stream()

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/reporting/Tracing.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/reporting/Tracing.java
@@ -4,7 +4,9 @@ import com.github.dbmdz.flusswerk.framework.model.Message;
 import de.huxhorn.sulky.ulid.ULID;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
 
+@Component
 public class Tracing {
 
   private final ConcurrentHashMap<Long, List<String>> tracingPathForThread;

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/MessageBrokerTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/MessageBrokerTest.java
@@ -1,14 +1,15 @@
 package com.github.dbmdz.flusswerk.framework.rabbitmq;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import com.github.dbmdz.flusswerk.framework.config.properties.RoutingProperties;
 import com.github.dbmdz.flusswerk.framework.exceptions.InvalidMessageException;
 import com.github.dbmdz.flusswerk.framework.model.Message;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,15 +74,6 @@ class MessageBrokerTest {
     }
     FailurePolicy failurePolicy = routing.getFailurePolicy(message);
     verify(rabbitClient).send(anyString(), eq(failurePolicy.getFailedRoutingKey()), eq(message));
-  }
-
-  @Test
-  @DisplayName("Should send multiple messages to the specified queue")
-  void sendMultipleMessagesShouldRouteMessagesToSpecifiedQueue() throws IOException {
-    String queue = "specified.queue";
-    List<Message> messages = Arrays.asList(new Message(), new Message(), new Message());
-    messageBroker.send(queue, messages);
-    verify(rabbitClient, times(messages.size())).send(any(), eq(queue), any());
   }
 
   @Test

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/MessageBrokerTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/MessageBrokerTest.java
@@ -1,24 +1,16 @@
 package com.github.dbmdz.flusswerk.framework.rabbitmq;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import com.github.dbmdz.flusswerk.framework.config.properties.RoutingProperties;
 import com.github.dbmdz.flusswerk.framework.exceptions.InvalidMessageException;
-import com.github.dbmdz.flusswerk.framework.model.Envelope;
 import com.github.dbmdz.flusswerk.framework.model.Message;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -84,13 +76,6 @@ class MessageBrokerTest {
   }
 
   @Test
-  @DisplayName("Should send a message to the output queue")
-  void sendShouldRouteMessageToOutputQueue() throws IOException {
-    messageBroker.send(new Message());
-    verify(rabbitClient).send(any(), eq(routing.getOutgoing().get("default")), any());
-  }
-
-  @Test
   @DisplayName("Should send multiple messages to the specified queue")
   void sendMultipleMessagesShouldRouteMessagesToSpecifiedQueue() throws IOException {
     String queue = "specified.queue";
@@ -105,48 +90,5 @@ class MessageBrokerTest {
     String queue = "a.very.special.queue";
     messageBroker.receive(queue);
     verify(rabbitClient).receive(queue, false);
-  }
-
-  @Test
-  @DisplayName("Default receive should pull from the input queue")
-  void defaultReceiveShouldPullTheInputQueue() throws IOException, InvalidMessageException {
-    messageBroker.receive();
-    verify(rabbitClient).receive(routing.getIncoming().get(0), false);
-  }
-
-  @Test
-  @DisplayName("getMessageCount should return all message counts")
-  void getMessageCountsShouldGetAllMessageCounts() throws IOException {
-    RoutingProperties routing = RoutingProperties.minimal(List.of("input1", "input2"), null);
-
-    Map<String, Long> expected = new HashMap<>();
-    expected.put("input1", 100L);
-    expected.put("input2", 200L);
-
-    for (String queue : expected.keySet()) {
-      when(rabbitClient.getMessageCount(queue)).thenReturn(expected.get(queue));
-    }
-
-    messageBroker = new MessageBroker(routing, rabbitClient);
-    assertThat(messageBroker.getMessageCounts()).isEqualTo(expected);
-  }
-
-  @Test
-  @DisplayName("invalidMessage should be ACKed and shifted into failed queue")
-  void handleInvalidMessage() throws IOException, InvalidMessageException {
-    String invalidMessageBody = "invalid";
-
-    Envelope envelope = new Envelope();
-    envelope.setDeliveryTag(1);
-    envelope.setBody(invalidMessageBody);
-    envelope.setSource("some.input.queue");
-    when(rabbitClient.receive(eq("some.input.queue"), eq(false)))
-        .thenThrow(new InvalidMessageException(envelope, "Invalid message"));
-
-    Assertions.assertThat(messageBroker.receive()).isNull();
-
-    verify(rabbitClient, times(1)).ack(envelope);
-    verify(rabbitClient, times(1))
-        .sendRaw(anyString(), eq("some.input.queue.failed"), eq(invalidMessageBody.getBytes()));
   }
 }

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitMQTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitMQTest.java
@@ -1,9 +1,7 @@
 package com.github.dbmdz.flusswerk.framework.rabbitmq;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.github.dbmdz.flusswerk.framework.config.properties.RoutingProperties;
 import com.github.dbmdz.flusswerk.framework.model.Message;
@@ -16,18 +14,24 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @DisplayName("RabbitMQ")
+@ExtendWith(MockitoExtension.class)
 class RabbitMQTest {
 
   private static final List<String> incoming = List.of("first.incoming", "first.incoming");
   private static final Map<String, String> outgoing =
       Map.of("first.rout", "first.outgoing", "second.route", "second.outgoing");
 
-  private Channel channel;
+  @Mock private Channel channel;
+  @Mock private RabbitClient rabbitClient;
+
   private RabbitMQ rabbitMQ;
   private Tracing tracing;
 
@@ -47,8 +51,6 @@ class RabbitMQTest {
   @BeforeEach
   void setUp() {
     var routing = RoutingProperties.minimal(incoming, outgoing);
-    var rabbitClient = mock(RabbitClient.class);
-    channel = mock(Channel.class);
     when(rabbitClient.getChannel()).thenReturn(channel);
     tracing = new Tracing();
     rabbitMQ = new RabbitMQ(routing, rabbitClient, mock(MessageBroker.class), tracing);
@@ -58,7 +60,7 @@ class RabbitMQTest {
   @ParameterizedTest
   @MethodSource("routesAndTopics")
   void shouldProvideMatchingTopicsForRoutes(String route, String topic) {
-    var expected = new Topic(topic, mock(MessageBroker.class), tracing);
+    var expected = new Topic(topic, "exchange", rabbitClient, tracing);
     assertThat(rabbitMQ.route(route)).isEqualTo(expected);
   }
 
@@ -66,14 +68,14 @@ class RabbitMQTest {
   @ParameterizedTest
   @MethodSource("topics")
   void shouldProvideAllTopics(String name) {
-    var expected = new Topic(name, mock(MessageBroker.class), tracing);
+    var expected = new Topic(name, "exchange", rabbitClient, tracing);
     assertThat(rabbitMQ.topic(name)).isEqualTo(expected);
   }
 
   @DisplayName("should provide unknown topic")
   @Test
   void shouldProvideUnknownTopic() {
-    var expected = new Topic("some.queue", mock(MessageBroker.class), tracing);
+    var expected = new Topic("some.queue", "exchange", rabbitClient, tracing);
     assertThat(rabbitMQ.topic("some.queue")).isEqualTo(expected);
   }
 

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitMQTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitMQTest.java
@@ -53,7 +53,7 @@ class RabbitMQTest {
     var routing = RoutingProperties.minimal(incoming, outgoing);
     when(rabbitClient.getChannel()).thenReturn(channel);
     tracing = new Tracing();
-    rabbitMQ = new RabbitMQ(routing, rabbitClient, mock(MessageBroker.class), tracing);
+    rabbitMQ = new RabbitMQ(routing, rabbitClient, tracing);
   }
 
   @DisplayName("should provide matching topics for routes")

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitMQTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/RabbitMQTest.java
@@ -31,6 +31,7 @@ class RabbitMQTest {
 
   @Mock private Channel channel;
   @Mock private RabbitClient rabbitClient;
+  @Mock private MessageBroker messageBroker;
 
   private RabbitMQ rabbitMQ;
   private Tracing tracing;
@@ -53,7 +54,7 @@ class RabbitMQTest {
     var routing = RoutingProperties.minimal(incoming, outgoing);
     when(rabbitClient.getChannel()).thenReturn(channel);
     tracing = new Tracing();
-    rabbitMQ = new RabbitMQ(routing, rabbitClient, tracing);
+    rabbitMQ = new RabbitMQ(routing, rabbitClient, tracing, messageBroker);
   }
 
   @DisplayName("should provide matching topics for routes")

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/TopicTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/rabbitmq/TopicTest.java
@@ -14,19 +14,22 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @DisplayName("A Topic")
+@ExtendWith(MockitoExtension.class)
 class TopicTest {
 
-  private MessageBroker messageBroker;
+  @Mock private RabbitClient rabbitClient;
+  @Mock private Tracing tracing;
+
   private Topic topic;
-  private Tracing tracing;
 
   @BeforeEach
   void setUp() {
-    messageBroker = mock(MessageBroker.class);
-    tracing = mock(Tracing.class);
-    topic = new Topic("test.topic", messageBroker, tracing);
+    topic = new Topic("test.topic", "text.exchange", rabbitClient, tracing);
   }
 
   @DisplayName("should send a single message")
@@ -34,7 +37,7 @@ class TopicTest {
   void shouldSendOneMessage() throws IOException {
     var message = new TestMessage("123");
     topic.send(message);
-    verify(messageBroker).send(any(), eq(message));
+    verify(rabbitClient).send(any(), any(), eq(message));
   }
 
   @DisplayName("should send all messages")
@@ -42,20 +45,22 @@ class TopicTest {
   void shouldSendManyMessages() throws IOException {
     List<Message> messages = List.of(new TestMessage("1"), new TestMessage("2"));
     topic.send(messages);
-    verify(messageBroker).send(any(), eq(messages));
+    for (Message message : messages) {
+      verify(rabbitClient).send(any(), any(), eq(message));
+    }
   }
 
   @DisplayName("should be equal to another identical topic")
   @Test
   void testEquals() {
-    var expected = new Topic(topic.getName(), mock(MessageBroker.class), tracing);
+    var expected = new Topic(topic.getName(), "test.exchange", mock(RabbitClient.class), tracing);
     assertThat(topic).isEqualTo(expected);
   }
 
   @DisplayName("should have the same hash code as identical topic")
   @Test
   void testHashCode() {
-    var expected = new Topic(topic.getName(), mock(MessageBroker.class), tracing);
+    var expected = new Topic(topic.getName(), "test.exchange", mock(RabbitClient.class), tracing);
     assertThat(topic.hashCode()).isEqualTo(expected.hashCode());
   }
 

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/NoFlowTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/NoFlowTest.java
@@ -9,8 +9,13 @@ import com.github.dbmdz.flusswerk.framework.config.properties.RoutingProperties;
 import com.github.dbmdz.flusswerk.framework.engine.Engine;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.model.Message;
+import com.github.dbmdz.flusswerk.framework.monitoring.FlusswerkMetrics;
+import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitClient;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
+import com.github.dbmdz.flusswerk.framework.reporting.Tracing;
 import com.github.dbmdz.flusswerk.integration.NoFlowTest.NoFlowTestConfiguration;
 import java.io.IOException;
 import java.util.List;
@@ -38,7 +43,13 @@ import org.testcontainers.junit.jupiter.Testcontainers;
     classes = {
       FlusswerkPropertiesConfiguration.class,
       FlusswerkConfiguration.class,
-      NoFlowTestConfiguration.class
+      NoFlowTestConfiguration.class,
+      MessageBroker.class,
+      RabbitClient.class,
+      RabbitMQ.class,
+      Tracing.class,
+      MeterFactory.class,
+      FlusswerkMetrics.class
     })
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When Flusswerk is created without a Flow")

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/NoFlowTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/NoFlowTest.java
@@ -9,10 +9,6 @@ import com.github.dbmdz.flusswerk.framework.config.properties.RoutingProperties;
 import com.github.dbmdz.flusswerk.framework.engine.Engine;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.model.Message;
-import com.github.dbmdz.flusswerk.framework.monitoring.FlusswerkMetrics;
-import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitClient;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
 import com.github.dbmdz.flusswerk.framework.reporting.Tracing;
@@ -29,6 +25,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfigu
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ContextConfiguration;
@@ -44,13 +41,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       FlusswerkPropertiesConfiguration.class,
       FlusswerkConfiguration.class,
       NoFlowTestConfiguration.class,
-      MessageBroker.class,
-      RabbitClient.class,
-      RabbitMQ.class,
       Tracing.class,
-      MeterFactory.class,
-      FlusswerkMetrics.class
     })
+@ComponentScan({
+  "com.github.dbmdz.flusswerk.framework.rabbitmq",
+  "com.github.dbmdz.flusswerk.framework.monitoring",
+})
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When Flusswerk is created without a Flow")
 @Testcontainers

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/ReconnectTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/ReconnectTest.java
@@ -12,10 +12,6 @@ import com.github.dbmdz.flusswerk.framework.flow.builder.FlowBuilder;
 import com.github.dbmdz.flusswerk.framework.jackson.FlusswerkObjectMapper;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.model.Message;
-import com.github.dbmdz.flusswerk.framework.monitoring.FlusswerkMetrics;
-import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitClient;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
 import com.github.dbmdz.flusswerk.framework.reporting.Tracing;
@@ -47,6 +43,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfigu
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.annotation.DirtiesContext;
@@ -66,13 +63,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       FlusswerkPropertiesConfiguration.class,
       FlusswerkConfiguration.class,
       ReconnectTest.FlowConfiguration.class,
-      MessageBroker.class,
-      RabbitClient.class,
-      RabbitMQ.class,
       Tracing.class,
-      MeterFactory.class,
-      FlusswerkMetrics.class
     })
+@ComponentScan({
+  "com.github.dbmdz.flusswerk.framework.rabbitmq",
+  "com.github.dbmdz.flusswerk.framework.monitoring",
+})
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When the RabbitMQ connection is lost")
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/ReconnectTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/ReconnectTest.java
@@ -12,8 +12,13 @@ import com.github.dbmdz.flusswerk.framework.flow.builder.FlowBuilder;
 import com.github.dbmdz.flusswerk.framework.jackson.FlusswerkObjectMapper;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.model.Message;
+import com.github.dbmdz.flusswerk.framework.monitoring.FlusswerkMetrics;
+import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitClient;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
+import com.github.dbmdz.flusswerk.framework.reporting.Tracing;
 import com.github.dbmdz.flusswerk.integration.RabbitUtil;
 import com.github.dbmdz.flusswerk.integration.TestMessage;
 import com.rabbitmq.client.AMQP.BasicProperties;
@@ -60,7 +65,13 @@ import org.testcontainers.junit.jupiter.Testcontainers;
     classes = {
       FlusswerkPropertiesConfiguration.class,
       FlusswerkConfiguration.class,
-      ReconnectTest.FlowConfiguration.class
+      ReconnectTest.FlowConfiguration.class,
+      MessageBroker.class,
+      RabbitClient.class,
+      RabbitMQ.class,
+      Tracing.class,
+      MeterFactory.class,
+      FlusswerkMetrics.class
     })
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When the RabbitMQ connection is lost")

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/RetryTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/RetryTest.java
@@ -13,8 +13,13 @@ import com.github.dbmdz.flusswerk.framework.flow.FlowSpec;
 import com.github.dbmdz.flusswerk.framework.flow.builder.FlowBuilder;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.model.Message;
+import com.github.dbmdz.flusswerk.framework.monitoring.FlusswerkMetrics;
+import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitClient;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
+import com.github.dbmdz.flusswerk.framework.reporting.Tracing;
 import com.github.dbmdz.flusswerk.integration.RabbitUtil;
 import com.github.dbmdz.flusswerk.integration.TestMessage;
 import java.io.IOException;
@@ -49,6 +54,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       FlusswerkPropertiesConfiguration.class,
       FlusswerkConfiguration.class,
       RetryTest.FlowConfiguration.class,
+      MessageBroker.class,
+      RabbitClient.class,
+      RabbitMQ.class,
+      Tracing.class,
+      MeterFactory.class,
+      FlusswerkMetrics.class
     })
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When processing for a message fails")

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/RetryTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/RetryTest.java
@@ -13,10 +13,6 @@ import com.github.dbmdz.flusswerk.framework.flow.FlowSpec;
 import com.github.dbmdz.flusswerk.framework.flow.builder.FlowBuilder;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
 import com.github.dbmdz.flusswerk.framework.model.Message;
-import com.github.dbmdz.flusswerk.framework.monitoring.FlusswerkMetrics;
-import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitClient;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
 import com.github.dbmdz.flusswerk.framework.reporting.Tracing;
@@ -37,6 +33,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfigu
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.annotation.DirtiesContext;
@@ -54,13 +51,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       FlusswerkPropertiesConfiguration.class,
       FlusswerkConfiguration.class,
       RetryTest.FlowConfiguration.class,
-      MessageBroker.class,
-      RabbitClient.class,
-      RabbitMQ.class,
       Tracing.class,
-      MeterFactory.class,
-      FlusswerkMetrics.class
     })
+@ComponentScan({
+  "com.github.dbmdz.flusswerk.framework.rabbitmq",
+  "com.github.dbmdz.flusswerk.framework.monitoring",
+})
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When processing for a message fails")
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/SkipProcessingTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/SkipProcessingTest.java
@@ -12,8 +12,13 @@ import com.github.dbmdz.flusswerk.framework.exceptions.SkipProcessingException;
 import com.github.dbmdz.flusswerk.framework.flow.FlowSpec;
 import com.github.dbmdz.flusswerk.framework.flow.builder.FlowBuilder;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
+import com.github.dbmdz.flusswerk.framework.monitoring.FlusswerkMetrics;
+import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitClient;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
+import com.github.dbmdz.flusswerk.framework.reporting.Tracing;
 import com.github.dbmdz.flusswerk.integration.RabbitUtil;
 import com.github.dbmdz.flusswerk.integration.TestMessage;
 import java.io.IOException;
@@ -46,6 +51,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       FlusswerkPropertiesConfiguration.class,
       FlusswerkConfiguration.class,
       SkipProcessingTest.FlowConfiguration.class,
+      MessageBroker.class,
+      RabbitClient.class,
+      RabbitMQ.class,
+      Tracing.class,
+      MeterFactory.class,
+      FlusswerkMetrics.class
     })
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When Flusswerk skips a message")

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/SkipProcessingTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/SkipProcessingTest.java
@@ -12,10 +12,6 @@ import com.github.dbmdz.flusswerk.framework.exceptions.SkipProcessingException;
 import com.github.dbmdz.flusswerk.framework.flow.FlowSpec;
 import com.github.dbmdz.flusswerk.framework.flow.builder.FlowBuilder;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
-import com.github.dbmdz.flusswerk.framework.monitoring.FlusswerkMetrics;
-import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitClient;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
 import com.github.dbmdz.flusswerk.framework.reporting.Tracing;
@@ -34,6 +30,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfigu
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.annotation.DirtiesContext;
@@ -51,13 +48,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       FlusswerkPropertiesConfiguration.class,
       FlusswerkConfiguration.class,
       SkipProcessingTest.FlowConfiguration.class,
-      MessageBroker.class,
-      RabbitClient.class,
-      RabbitMQ.class,
       Tracing.class,
-      MeterFactory.class,
-      FlusswerkMetrics.class
     })
+@ComponentScan({
+  "com.github.dbmdz.flusswerk.framework.rabbitmq",
+  "com.github.dbmdz.flusswerk.framework.monitoring",
+})
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When Flusswerk skips a message")
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/SuccessfulProcessingTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/SuccessfulProcessingTest.java
@@ -11,8 +11,13 @@ import com.github.dbmdz.flusswerk.framework.engine.Engine;
 import com.github.dbmdz.flusswerk.framework.flow.FlowSpec;
 import com.github.dbmdz.flusswerk.framework.flow.builder.FlowBuilder;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
+import com.github.dbmdz.flusswerk.framework.monitoring.FlusswerkMetrics;
+import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
+import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitClient;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
+import com.github.dbmdz.flusswerk.framework.reporting.Tracing;
 import com.github.dbmdz.flusswerk.integration.RabbitUtil;
 import com.github.dbmdz.flusswerk.integration.TestMessage;
 import java.io.IOException;
@@ -44,7 +49,13 @@ import org.testcontainers.junit.jupiter.Testcontainers;
     classes = {
       FlusswerkPropertiesConfiguration.class,
       FlusswerkConfiguration.class,
-      SuccessfulProcessingTest.FlowConfiguration.class
+      SuccessfulProcessingTest.FlowConfiguration.class,
+      MessageBroker.class,
+      RabbitClient.class,
+      RabbitMQ.class,
+      Tracing.class,
+      MeterFactory.class,
+      FlusswerkMetrics.class
     })
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When Flusswerk successfully processes a message")

--- a/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/SuccessfulProcessingTest.java
+++ b/integration-tests/src/test/java/com/github/dbmdz/flusswerk/integration/processing/SuccessfulProcessingTest.java
@@ -11,10 +11,6 @@ import com.github.dbmdz.flusswerk.framework.engine.Engine;
 import com.github.dbmdz.flusswerk.framework.flow.FlowSpec;
 import com.github.dbmdz.flusswerk.framework.flow.builder.FlowBuilder;
 import com.github.dbmdz.flusswerk.framework.model.IncomingMessageType;
-import com.github.dbmdz.flusswerk.framework.monitoring.FlusswerkMetrics;
-import com.github.dbmdz.flusswerk.framework.monitoring.MeterFactory;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.MessageBroker;
-import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitClient;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitConnection;
 import com.github.dbmdz.flusswerk.framework.rabbitmq.RabbitMQ;
 import com.github.dbmdz.flusswerk.framework.reporting.Tracing;
@@ -33,6 +29,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfigu
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.test.annotation.DirtiesContext;
@@ -50,13 +47,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       FlusswerkPropertiesConfiguration.class,
       FlusswerkConfiguration.class,
       SuccessfulProcessingTest.FlowConfiguration.class,
-      MessageBroker.class,
-      RabbitClient.class,
-      RabbitMQ.class,
       Tracing.class,
-      MeterFactory.class,
-      FlusswerkMetrics.class
     })
+@ComponentScan({
+  "com.github.dbmdz.flusswerk.framework.rabbitmq",
+  "com.github.dbmdz.flusswerk.framework.monitoring",
+})
 @Import({MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @DisplayName("When Flusswerk successfully processes a message")
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)


### PR DESCRIPTION
This PR completes the introduction of the new and highly ergonomic RabbitMQ and routing API as partly introduced in Flusswerk 5.

Public access to the internal class `MessageBroker` is not longer necessary at all and was deprecated before. Therefore, `MessageBroker` is removed from the public interface.