### PR TITLE
Fix missing log fields

### DIFF
--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/config/FlusswerkConfiguration.java
@@ -129,7 +129,7 @@ public class FlusswerkConfiguration {
                                 metrics,
                                 messageBroker,
                                 processReport.orElseGet(
-                                    () -> new DefaultProcessReport(appProperties.name())),
+                                    () -> new DefaultProcessReport(appProperties.name(), tracing)),
                                 taskQueue,
                                 tracing))
                     .collect(

--- a/framework/src/main/java/com/github/dbmdz/flusswerk/framework/reporting/DefaultProcessReport.java
+++ b/framework/src/main/java/com/github/dbmdz/flusswerk/framework/reporting/DefaultProcessReport.java
@@ -14,14 +14,16 @@ public class DefaultProcessReport implements ProcessReport {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultProcessReport.class);
 
   private final String name;
+  private final Tracing tracing;
 
-  public DefaultProcessReport(String name) {
+  public DefaultProcessReport(String name, Tracing tracing) {
     this.name = requireNonNull(name);
+    this.tracing = requireNonNull(tracing);
   }
 
   @Override
   public void reportSuccess(Message message) {
-    LOGGER.info("{} successful", name);
+    LOGGER.info("{} successful", name, keyValue("tracing", tracing.tracingPath()));
   }
 
   @Override
@@ -64,7 +66,7 @@ public class DefaultProcessReport implements ProcessReport {
             name,
             e.getMessage(),
             keyValue("amqp_message", message.toString()),
-            keyValue("exception", e.toString()));
+            e);
   }
 
   @Override
@@ -79,7 +81,7 @@ public class DefaultProcessReport implements ProcessReport {
             messagesSent,
             e.getMessage(),
             keyValue("amqp_message", message.toString()),
-            keyValue("exception", e.toString()));
+            e);
   }
 
   @Override

--- a/framework/src/test/java/com/github/dbmdz/flusswerk/framework/reporting/DefaultProcessReportTest.java
+++ b/framework/src/test/java/com/github/dbmdz/flusswerk/framework/reporting/DefaultProcessReportTest.java
@@ -1,6 +1,7 @@
 package com.github.dbmdz.flusswerk.framework.reporting;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -29,7 +30,7 @@ class DefaultProcessReportTest {
     listAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
     listAppender.start();
     logger.addAppender(listAppender);
-    defaultProcessReport = new DefaultProcessReport("testapp");
+    defaultProcessReport = new DefaultProcessReport("testapp", mock(Tracing.class));
   }
 
   @DisplayName("should report success")


### PR DESCRIPTION
This PR adds back the missing `stack_trace` and `stack_hash` fields, as well as the `tracing` field in logfiles for setups running with the default configs.