### PR TITLE
CI: Update version of Ubuntu image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         java: [17]
@@ -35,7 +35,7 @@ jobs:
           - 6379:6379
   publish:
     if: (github.event_name == 'push' && contains(github.ref, 'main')) || github.event_name == 'release'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Hi,

this PR introduces Ubuntu 24.04 as new image version for both builds and releases.