### PR TITLE
Remove Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - directory: "/"
-    open-pull-requests-limit: 10
-    package-ecosystem: maven
-    schedule:
-      interval: daily
-      time: "04:00"


### PR DESCRIPTION
Hi,

as we want to proceed with Renovate, this PR removes Dependabot configuration (integeration on repository-level has already been removed).