### PR TITLE
Add lifecycle management to tear down connections

### DIFF
--- a/framework/src/main/java/dev/mdz/flusswerk/FlusswerkApplication.java
+++ b/framework/src/main/java/dev/mdz/flusswerk/FlusswerkApplication.java
@@ -1,7 +1,6 @@
 package dev.mdz.flusswerk;
 
 import dev.mdz.flusswerk.engine.Engine;
-import jakarta.annotation.PreDestroy;
 import java.util.Optional;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -13,23 +12,18 @@ public class FlusswerkApplication implements CommandLineRunner {
 
   protected final Engine engine; // can be null if Flusswerk is only used to send messages
 
+  public FlusswerkApplication() {
+    this.engine = null; // for backwards compatibility, will be removed
+  }
+
+  @Deprecated
   public FlusswerkApplication(Optional<Engine> engine) {
+    // for backwards compatibility, will be removed
     this.engine = engine.orElse(null);
   }
 
   @Override
   public void run(String... args) {
-    if (engine == null) {
-      return;
-    }
-    engine.start();
-  }
-
-  @PreDestroy
-  public void shutdown() {
-    if (engine == null) {
-      return;
-    }
-    engine.stop();
+    // nothing to do
   }
 }

--- a/framework/src/main/java/dev/mdz/flusswerk/LifecyclePhases.java
+++ b/framework/src/main/java/dev/mdz/flusswerk/LifecyclePhases.java
@@ -1,0 +1,10 @@
+package dev.mdz.flusswerk;
+
+/** Define application life cycle phases for ordering startup and shutdown of components. */
+public class LifecyclePhases {
+  /** Setup/tear down connections to infrastructure components like RabbitMQ. */
+  public static final int INFRASTRUCTURE = 0;
+
+  /** Start/stop processing messages. */
+  public static final int PROCESSING = 1;
+}

--- a/framework/src/main/java/dev/mdz/flusswerk/LifecyclePhases.java
+++ b/framework/src/main/java/dev/mdz/flusswerk/LifecyclePhases.java
@@ -3,7 +3,7 @@ package dev.mdz.flusswerk;
 /** Define application life cycle phases for ordering startup and shutdown of components. */
 public class LifecyclePhases {
   /** Setup/tear down connections to infrastructure components like RabbitMQ. */
-  public static final int INFRASTRUCTURE = 0;
+  public static final int CONNECTIONS = 0;
 
   /** Start/stop processing messages. */
   public static final int PROCESSING = 1;

--- a/framework/src/main/java/dev/mdz/flusswerk/engine/Engine.java
+++ b/framework/src/main/java/dev/mdz/flusswerk/engine/Engine.java
@@ -75,6 +75,7 @@ public class Engine implements ChannelListener, SmartLifecycle {
    */
   @Override
   public void start() {
+    LOGGER.info("Starting RabbitMQ consumers");
     if (!startOnlyOnce.tryAcquire()) {
       LOGGER.error("Engine had already been started once. Starting again is not possible.");
       return;
@@ -101,6 +102,7 @@ public class Engine implements ChannelListener, SmartLifecycle {
    */
   @Override
   public void stop() {
+    LOGGER.info("Stopping RabbitMQ consumers");
     // Stop receiving new messages
     consumers.forEach(
         consumer -> {

--- a/framework/src/main/java/dev/mdz/flusswerk/rabbitmq/RabbitClient.java
+++ b/framework/src/main/java/dev/mdz/flusswerk/rabbitmq/RabbitClient.java
@@ -50,6 +50,8 @@ public class RabbitClient {
     channel = connection.getChannel();
     // We need a recoverable connection since we don't want to handle connection and channel
     // recovery ourselves.
+    // This is done in constructor instead of lifecycle events to fail fast and not leave a half
+    // configured application running.
     if (channel instanceof RecoverableChannel rc) {
       rc.addRecoveryListener(
           new RecoveryListener() {

--- a/framework/src/main/java/dev/mdz/flusswerk/rabbitmq/RabbitConnection.java
+++ b/framework/src/main/java/dev/mdz/flusswerk/rabbitmq/RabbitConnection.java
@@ -112,13 +112,13 @@ public class RabbitConnection implements SmartLifecycle {
   }
 
   public void close() {
-    if (channel == null || !channel.isOpen()) {
+    if (connection == null || !connection.isOpen()) {
       return;
     }
     try {
-      channel.close(AMQP.CONNECTION_FORCED, "Application shutdown");
-    } catch (TimeoutException | IOException exception) {
-      LOGGER.error("Could not close RabbitMQ channel", exception);
+      connection.close(AMQP.CONNECTION_FORCED, "Application shutdown");
+    } catch (IOException exception) {
+      LOGGER.error("Could not close RabbitMQ connection", exception);
     }
   }
 
@@ -140,10 +140,12 @@ public class RabbitConnection implements SmartLifecycle {
   @Override
   public void start() {
     // nothing to do, connection is established in constructor for fail-fast behavior
+    LOGGER.info("Starting RabbitMQ connection");
   }
 
   @Override
   public void stop() {
+    LOGGER.info("Closing RabbitMQ connection");
     close();
   }
 }

--- a/framework/src/main/java/dev/mdz/flusswerk/rabbitmq/RabbitConnection.java
+++ b/framework/src/main/java/dev/mdz/flusswerk/rabbitmq/RabbitConnection.java
@@ -1,5 +1,6 @@
 package dev.mdz.flusswerk.rabbitmq;
 
+import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.ConnectionFactory;
@@ -104,6 +105,17 @@ public class RabbitConnection {
       if (b.getChannel() == channel) {
         connection.recoverBinding(b, true);
       }
+    }
+  }
+
+  public void close() {
+    if (channel == null || !channel.isOpen()) {
+      return;
+    }
+    try {
+      channel.close(AMQP.CONNECTION_FORCED, "Application shutdown");
+    } catch (TimeoutException | IOException exception) {
+      LOGGER.error("Could not close RabbitMQ channel", exception);
     }
   }
 }


### PR DESCRIPTION
This is a first draft to use Spring's life cycle management to gracefully stop the connection to RabbitMQ and simplify the setup of clicent applications.

In further versions, this could be used to build a more resilient connection handling in case of server reboots or RabbitMQ restarts.